### PR TITLE
Custom templating engine

### DIFF
--- a/ballsdex/core/admin/resources.py
+++ b/ballsdex/core/admin/resources.py
@@ -262,7 +262,7 @@ class BallInstanceResource(Model):
         ),
         filters.ForeignKey(model=Ball, name="ball", label="Ball"),
         filters.ForeignKey(model=Special, name="special", label="Special"),
-        filters.Boolean(name="shiny", label="Shiny"),
+        filters.Date(name="catch_date", label="Catch date"),
         filters.Boolean(name="favorite", label="Favorite"),
         filters.Search(
             name="player__discord_id",
@@ -282,7 +282,6 @@ class BallInstanceResource(Model):
         "player",
         "catch_date",
         "server_id",
-        "shiny",
         "special",
         "favorite",
         "health_bonus",

--- a/ballsdex/core/image_generator/image_gen.py
+++ b/ballsdex/core/image_generator/image_gen.py
@@ -30,10 +30,7 @@ def draw_card(ball_instance: "BallInstance"):
     ball = ball_instance.countryball
     ball_health = (237, 115, 101, 255)
 
-    if ball_instance.shiny:
-        image = Image.open(str(SOURCES_PATH / "shiny.png"))
-        ball_health = (255, 255, 255, 255)
-    elif special_image := ball_instance.special_card:
+    if special_image := ball_instance.special_card:
         image = Image.open("." + special_image)
     else:
         image = Image.open("." + ball.cached_regime.background)

--- a/ballsdex/core/models.py
+++ b/ballsdex/core/models.py
@@ -85,6 +85,12 @@ class GuildConfig(models.Model):
 class Regime(models.Model):
     name = fields.CharField(max_length=64)
     background = fields.CharField(max_length=200, description="1428x2000 PNG image")
+    template = fields.CharField(
+        max_length=64,
+        null=True,
+        default=None,
+        help="Key to a custom template definition in the templates.yml file.",
+    )
 
     def __str__(self):
         return self.name
@@ -106,12 +112,18 @@ class Special(models.Model):
         null=True,
         default=None,
     )
-    start_date = fields.DatetimeField()
-    end_date = fields.DatetimeField()
+    start_date = fields.DatetimeField(null=True, default=None)
+    end_date = fields.DatetimeField(null=True, default=None)
     rarity = fields.FloatField(
         description="Value between 0 and 1, chances of using this special background."
     )
     background = fields.CharField(max_length=200, description="1428x2000 PNG image", null=True)
+    template = fields.CharField(
+        max_length=64,
+        null=True,
+        default=None,
+        help="Key to a custom template definition in the templates.yml file.",
+    )
     emoji = fields.CharField(
         max_length=20,
         description="Either a unicode character or a discord emoji ID",
@@ -205,7 +217,6 @@ class BallInstance(models.Model):
     server_id = fields.BigIntField(
         description="Discord server ID where this ball was caught", null=True
     )
-    shiny = fields.BooleanField(default=False)
     special: fields.ForeignKeyRelation[Special] | None = fields.ForeignKeyField(
         "models.Special", null=True, default=None, on_delete=fields.SET_NULL
     )
@@ -266,8 +277,6 @@ class BallInstance(models.Model):
             emotes += "🔒"
         if self.favorite and not is_trade:
             emotes += "❤️"
-        if self.shiny:
-            emotes += "✨"
         if emotes:
             emotes += " "
         if self.specialcard:

--- a/ballsdex/core/utils/transformers.py
+++ b/ballsdex/core/utils/transformers.py
@@ -165,8 +165,6 @@ class BallInstanceTransformer(ModelTransformer[BallInstance]):
 
         if (special := getattr(interaction.namespace, "special", None)) and special.isdigit():
             balls_queryset = balls_queryset.filter(special_id=int(special))
-        if (shiny := getattr(interaction.namespace, "shiny", None)) and shiny is not None:
-            balls_queryset = balls_queryset.filter(shiny=shiny)
 
         if interaction.command and (trade_type := interaction.command.extras.get("trade", None)):
             if trade_type == TradeCommandType.PICK:

--- a/ballsdex/packages/admin/cog.py
+++ b/ballsdex/packages/admin/cog.py
@@ -437,7 +437,6 @@ class Admin(commands.GroupCog):
         countryball: BallTransform,
         user: discord.User,
         special: SpecialTransform | None = None,
-        shiny: bool | None = None,
         health_bonus: int | None = None,
         attack_bonus: int | None = None,
     ):
@@ -449,8 +448,6 @@ class Admin(commands.GroupCog):
         countryball: Ball
         user: discord.User
         special: Special | None
-        shiny: bool
-            Omit this to make it random.
         health_bonus: int | None
             Omit this to make it random.
         attack_bonus: int | None
@@ -465,7 +462,6 @@ class Admin(commands.GroupCog):
         instance = await BallInstance.create(
             ball=countryball,
             player=player,
-            shiny=(shiny if shiny is not None else random.randint(1, 2048) == 1),
             attack_bonus=(
                 attack_bonus
                 if attack_bonus is not None
@@ -482,13 +478,11 @@ class Admin(commands.GroupCog):
             f"`{countryball.country}` {settings.collectible_name} was successfully given to "
             f"`{user}`.\nSpecial: `{special.name if special else None}` • ATK: "
             f"`{instance.attack_bonus:+d}` • HP:`{instance.health_bonus:+d}` "
-            f"• Shiny: `{instance.shiny}`"
         )
         await log_action(
             f"{interaction.user} gave {settings.collectible_name} "
             f"{countryball.country} to {user}. (Special={special.name if special else None} "
-            f"ATK={instance.attack_bonus:+d} HP={instance.health_bonus:+d} "
-            f"shiny={instance.shiny}).",
+            f"ATK={instance.attack_bonus:+d} HP={instance.health_bonus:+d}).",
             self.bot,
         )
 
@@ -854,7 +848,6 @@ class Admin(commands.GroupCog):
             f"**Attack bonus:** {ball.attack_bonus}\n"
             f"**Health bonus:** {ball.health_bonus}\n"
             f"**Health:** {ball.health}\n"
-            f"**Shiny:** {ball.shiny}\n"
             f"**Special:** {ball.special.name if ball.special else None}\n"
             f"**Caught at:** {format_dt(ball.catch_date, style='R')}\n"
             f"**Spawned at:** {spawned_time}\n"
@@ -1014,7 +1007,6 @@ class Admin(commands.GroupCog):
         interaction: discord.Interaction,
         user: discord.User | None = None,
         countryball: BallTransform | None = None,
-        shiny: bool | None = None,
         special: SpecialTransform | None = None,
     ):
         """
@@ -1025,7 +1017,6 @@ class Admin(commands.GroupCog):
         user: discord.User
             The user you want to count the countryballs of.
         countryball: Ball
-        shiny: bool
         special: Special
         """
         if interaction.response.is_done():
@@ -1033,8 +1024,6 @@ class Admin(commands.GroupCog):
         filters = {}
         if countryball:
             filters["ball"] = countryball
-        if shiny is not None:
-            filters["shiny"] = shiny
         if special:
             filters["special"] = special
         if user:
@@ -1045,15 +1034,14 @@ class Admin(commands.GroupCog):
         country = f"{countryball.country} " if countryball else ""
         plural = "s" if balls > 1 or balls == 0 else ""
         special_str = f"{special.name} " if special else ""
-        shiny_str = "shiny " if shiny else ""
         if user:
             await interaction.followup.send(
-                f"{user} has {balls} {special_str}{shiny_str}"
+                f"{user} has {balls} {special_str}"
                 f"{country}{settings.collectible_name}{plural}."
             )
         else:
             await interaction.followup.send(
-                f"There {verb} {balls} {special_str}{shiny_str}"
+                f"There {verb} {balls} {special_str}"
                 f"{country}{settings.collectible_name}{plural}."
             )
 

--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -205,7 +205,7 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             else:
                 countryballs = await player.balls.filter(**filters).order_by(sort.value)
         else:
-            countryballs = await player.balls.filter(**filters).order_by("-favorite", "-shiny")
+            countryballs = await player.balls.filter(**filters).order_by("-favorite")
 
         if len(countryballs) < 1:
             ball_txt = countryball.country if countryball else ""
@@ -248,7 +248,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         interaction: discord.Interaction["BallsDexBot"],
         user: discord.User | None = None,
         special: SpecialEnabledTransform | None = None,
-        shiny: bool | None = None,
     ):
         """
         Show your current completion of the BallsDex.
@@ -259,12 +258,10 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             The user whose completion you want to view, if not yours.
         special: Special
             The special you want to see the completion of
-        shiny: bool
-            Whether you want to see the completion of shiny countryballs
         """
         user_obj = user or interaction.user
         await interaction.response.defer(thinking=True)
-        extra_text = "shiny " if shiny else "" + f"{special.name} " if special else ""
+        extra_text = f"{special.name} " if special else ""
         if user is not None:
             try:
                 player = await Player.get(discord_id=user_obj.id)
@@ -307,8 +304,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             )
             return
 
-        if shiny is not None:
-            filters["shiny"] = shiny
         owned_countryballs = set(
             x[0]
             for x in await BallInstance.filter(**filters)
@@ -367,9 +362,8 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
 
         source = FieldPageSource(entries, per_page=5, inline=False, clear_description=False)
         special_str = f" ({special.name})" if special else ""
-        shiny_str = " shiny" if shiny else ""
         source.embed.description = (
-            f"{settings.bot_name}{special_str}{shiny_str} progression: "
+            f"{settings.bot_name}{special_str} progression: "
             f"**{round(len(owned_countryballs) / len(bot_countryballs) * 100, 1)}%**"
         )
         source.embed.colour = discord.Colour.blurple()
@@ -385,7 +379,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         interaction: discord.Interaction,
         countryball: BallInstanceTransform,
         special: SpecialEnabledTransform | None = None,
-        shiny: bool | None = None,
     ):
         """
         Display info from a specific countryball.
@@ -396,8 +389,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             The countryball you want to inspect
         special: Special
             Filter the results of autocompletion to a special event. Ignored afterwards.
-        shiny: bool
-            Filter the results of autocompletion to shinies. Ignored afterwards.
         """
         if not countryball:
             return
@@ -467,7 +458,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         interaction: discord.Interaction,
         countryball: BallInstanceTransform,
         special: SpecialEnabledTransform | None = None,
-        shiny: bool | None = None,
     ):
         """
         Set favorite countryballs.
@@ -478,8 +468,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             The countryball you want to set/unset as favorite
         special: Special
             Filter the results of autocompletion to a special event. Ignored afterwards.
-        shiny: bool
-            Filter the results of autocompletion to shinies. Ignored afterwards.
         """
         if not countryball:
             return
@@ -530,7 +518,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         user: discord.User,
         countryball: BallInstanceTransform,
         special: SpecialEnabledTransform | None = None,
-        shiny: bool | None = None,
     ):
         """
         Give a countryball to a user.
@@ -543,8 +530,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             The countryball you're giving away
         special: Special
             Filter the results of autocompletion to a special event. Ignored afterwards.
-        shiny: bool
-            Filter the results of autocompletion to shinies. Ignored afterwards.
         """
         if not countryball:
             return
@@ -655,7 +640,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         interaction: discord.Interaction,
         countryball: BallEnabledTransform | None = None,
         special: SpecialEnabledTransform | None = None,
-        shiny: bool | None = None,
         current_server: bool = False,
     ):
         """
@@ -667,8 +651,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
             The countryball you want to count
         special: Special
             The special you want to count
-        shiny: bool
-            Whether you want to count shiny countryballs
         current_server: bool
             Only count countryballs caught in the current server
         """
@@ -678,8 +660,6 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         filters = {}
         if countryball:
             filters["ball"] = countryball
-        if shiny is not None:
-            filters["shiny"] = shiny
         if special:
             filters["special"] = special
         if current_server:
@@ -689,10 +669,9 @@ class Balls(commands.GroupCog, group_name=settings.players_group_cog_name):
         balls = await BallInstance.filter(**filters).count()
         country = f"{countryball.country} " if countryball else ""
         plural = "s" if balls > 1 or balls == 0 else ""
-        shiny_str = "shiny " if shiny else ""
         special_str = f"{special.name} " if special else ""
         guild = f" caught in {interaction.guild.name}" if current_server else ""
         await interaction.followup.send(
-            f"You have {balls} {special_str}{shiny_str}"
+            f"You have {balls} {special_str}"
             f"{country}{settings.collectible_name}{plural}{guild}."
         )

--- a/ballsdex/packages/balls/countryballs_paginator.py
+++ b/ballsdex/packages/balls/countryballs_paginator.py
@@ -33,11 +33,10 @@ class CountryballsSelector(Pages):
         for ball in balls:
             emoji = self.bot.get_emoji(int(ball.countryball.emoji_id))
             favorite = "❤️ " if ball.favorite else ""
-            shiny = "✨ " if ball.shiny else ""
             special = ball.special_emoji(self.bot, True)
             options.append(
                 discord.SelectOption(
-                    label=f"{favorite}{shiny}{special}#{ball.pk:0X} {ball.countryball.country}",
+                    label=f"{favorite}{special}#{ball.pk:0X} {ball.countryball.country}",
                     description=(
                         f"ATK: {ball.attack}({ball.attack_bonus:+d}%) "
                         f"• HP: {ball.health}({ball.health_bonus:+d}%) • "

--- a/ballsdex/packages/countryballs/components.py
+++ b/ballsdex/packages/countryballs/components.py
@@ -16,7 +16,6 @@ from ballsdex.settings import settings
 
 if TYPE_CHECKING:
     from ballsdex.core.bot import BallsDexBot
-    from ballsdex.core.models import Special
     from ballsdex.packages.countryballs.countryball import CountryBall
 
 log = logging.getLogger("ballsdex.packages.countryballs.components")
@@ -83,8 +82,6 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
             )
 
             special = ""
-            if ball.shiny:
-                special += f"✨ ***It's a shiny {settings.collectible_name}!*** ✨\n"
             if ball.specialcard and ball.specialcard.catch_phrase:
                 special += f"*{ball.specialcard.catch_phrase}*\n"
             if has_caught_before:
@@ -119,12 +116,11 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
         bonus_health = self.ball.hp_bonus or random.randint(
             -settings.max_health_bonus, settings.max_health_bonus
         )
-        shiny = self.ball.shiny or random.randint(1, 2048) == 1
 
         # check if we can spawn cards with a special background
-        special: "Special | None" = None if shiny else self.ball.special
+        special = self.ball.special
         population = [x for x in specials.values() if x.start_date <= datetime_now() <= x.end_date]
-        if not special and not shiny and population:
+        if not special and population:
             # Here we try to determine what should be the chance of having a common card
             # since the rarity field is a value between 0 and 1, 1 being no common
             # and 0 only common, we get the remaining value by doing (1-rarity)
@@ -140,7 +136,6 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
         ball = await BallInstance.create(
             ball=self.ball.model,
             player=player,
-            shiny=shiny,
             special=special,
             attack_bonus=bonus_attack,
             health_bonus=bonus_health,
@@ -149,18 +144,15 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
         )
         if user.id in bot.catch_log:
             log.info(
-                f"{user} caught {settings.collectible_name}"
-                f" {self.ball.model}, {shiny=} {special=}",
+                f"{user} caught {settings.collectible_name}" f" {self.ball.model}, {special=}",
             )
         else:
             log.debug(
-                f"{user} caught {settings.collectible_name}"
-                f" {self.ball.model}, {shiny=} {special=}",
+                f"{user} caught {settings.collectible_name}" f" {self.ball.model}, {special=}",
             )
         if user.guild.member_count:
             caught_balls.labels(
                 country=self.ball.model.country,
-                shiny=shiny,
                 special=special,
                 # observe the size of the server, rounded to the nearest power of 10
                 guild_size=10 ** math.ceil(math.log(max(user.guild.member_count - 1, 1), 10)),

--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -521,7 +521,6 @@ class Player(commands.GroupCog):
             completion_percentage = "0.0%"
         caught_owned = [x for x in ball if x.trade_player is None]
         balls_owned = [x for x in ball]
-        shiny = [x for x in ball if x.shiny is True]
         special = [x for x in ball if x.special is not None]
         trades = await Trade.filter(
             Q(player1__discord_id=interaction.user.id) | Q(player2__discord_id=interaction.user.id)
@@ -551,7 +550,6 @@ class Player(commands.GroupCog):
             f"**Completion:** {completion_percentage}\n"
             f"**{settings.collectible_name.title()}s Owned:** {len(balls_owned):,}\n"
             f"**Caught {settings.collectible_name.title()}s Owned**: {len(caught_owned):,}\n"
-            f"**Shiny {settings.collectible_name.title()}s:** {len(shiny):,}\n"
             f"**Special {settings.collectible_name.title()}s:** {len(special):,}\n"
             f"**Trades Completed:** {trades:,}"
         )
@@ -636,13 +634,13 @@ async def get_items_csv(player: PlayerModel) -> BytesIO:
     )
     txt = (
         f"id,hex id,{settings.collectible_name},catch date,trade_player"
-        ",special,shiny,attack,attack bonus,hp,hp_bonus\n"
+        ",special,attack,attack bonus,hp,hp_bonus\n"
     )
     for ball in balls:
         txt += (
             f"{ball.id},{ball.id:0X},{ball.ball.country},{ball.catch_date},"  # type: ignore
             f"{ball.trade_player.discord_id if ball.trade_player else 'None'},{ball.special},"
-            f"{ball.shiny},{ball.attack},{ball.attack_bonus},{ball.health},{ball.health_bonus}\n"
+            f"{ball.attack},{ball.attack_bonus},{ball.health},{ball.health_bonus}\n"
         )
     return BytesIO(txt.encode("utf-8"))
 

--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -166,7 +166,6 @@ class Trade(commands.GroupCog):
         interaction: discord.Interaction,
         countryball: BallInstanceTransform,
         special: SpecialEnabledTransform | None = None,
-        shiny: bool | None = None,
     ):
         """
         Add a countryball to the ongoing trade.
@@ -177,8 +176,6 @@ class Trade(commands.GroupCog):
             The countryball you want to add to your proposal
         special: Special
             Filter the results of autocompletion to a special event. Ignored afterwards.
-        shiny: bool
-            Filter the results of autocompletion to shinies. Ignored afterwards.
         """
         if not countryball:
             return
@@ -240,7 +237,6 @@ class Trade(commands.GroupCog):
         self,
         interaction: discord.Interaction,
         countryball: BallEnabledTransform | None = None,
-        shiny: bool | None = None,
         special: SpecialEnabledTransform | None = None,
     ):
         """
@@ -250,8 +246,6 @@ class Trade(commands.GroupCog):
         ----------
         countryball: Ball
             The countryball you would like to filter the results to
-        shiny: bool
-            Filter the results to shinies
         special: Special
             Filter the results to a special event
         """
@@ -270,8 +264,6 @@ class Trade(commands.GroupCog):
         filters = {}
         if countryball:
             filters["ball"] = countryball
-        if shiny:
-            filters["shiny"] = shiny
         if special:
             filters["special"] = special
         filters["player__discord_id"] = interaction.user.id
@@ -296,7 +288,6 @@ class Trade(commands.GroupCog):
         interaction: discord.Interaction,
         countryball: BallInstanceTransform,
         special: SpecialEnabledTransform | None = None,
-        shiny: bool | None = None,
     ):
         """
         Remove a countryball from what you proposed in the ongoing trade.
@@ -307,8 +298,6 @@ class Trade(commands.GroupCog):
             The countryball you want to remove from your proposal
         special: Special
             Filter the results of autocompletion to a special event. Ignored afterwards.
-        shiny: bool
-            Filter the results of autocompletion to shinies. Ignored afterwards.
         """
         if not countryball:
             return

--- a/ballsdex/packages/trade/menu.py
+++ b/ballsdex/packages/trade/menu.py
@@ -400,11 +400,10 @@ class CountryballsSelector(Pages):
                 continue
             emoji = self.bot.get_emoji(int(ball.countryball.emoji_id))
             favorite = "❤️ " if ball.favorite else ""
-            shiny = "✨ " if ball.shiny else ""
             special = ball.special_emoji(self.bot, True)
             options.append(
                 discord.SelectOption(
-                    label=f"{favorite}{shiny}{special}#{ball.pk:0X} {ball.countryball.country}",
+                    label=f"{favorite}{special}#{ball.pk:0X} {ball.countryball.country}",
                     description=f"ATK: {ball.attack_bonus:+d}% • HP: {ball.health_bonus:+d}% • "
                     f"Caught on {ball.catch_date.strftime('%d/%m/%y %H:%M')}",
                     emoji=emoji,

--- a/migrations/models/36_20241009120300_update.sql
+++ b/migrations/models/36_20241009120300_update.sql
@@ -1,0 +1,28 @@
+-- upgrade --
+ALTER TABLE "regime" ADD "template" VARCHAR(64);
+ALTER TABLE "special" ADD "template" VARCHAR(64);
+ALTER TABLE "special" ALTER COLUMN "start_date" DROP NOT NULL;
+ALTER TABLE "special" ALTER COLUMN "end_date" DROP NOT NULL;
+
+WITH shiny_id AS (
+    INSERT INTO "special" (name, catch_phrase, rarity, emoji, background, template) VALUES
+    ('Shiny', '**It''s a shiny countryball!**', 0.00048828125,
+    '✨', '/ballsdex/core/image_generator/src/shiny.png', 'shiny')
+    RETURNING id);
+UPDATE "ballinstance" SET "special_id" = shiny_id WHERE "shiny" = true;
+
+ALTER TABLE "ballinstance" DROP COLUMN "shiny";
+-- downgrade --
+ALTER TABLE "ballinstance" ADD "shiny" BOOL NOT NULL  DEFAULT False;
+
+UPDATE "ballinstance" SET "shiny" = true
+FROM "special" s WHERE s.id = "special_id"
+AND s.name = 'Shiny' AND s.background = '/ballsdex/core/image_generator/src/shiny.png';
+
+DELETE FROM "special" WHERE
+    name = 'Shiny' AND background = '/ballsdex/core/image_generator/src/shiny.png';
+
+ALTER TABLE "regime" DROP COLUMN "template";
+ALTER TABLE "special" DROP COLUMN "template";
+ALTER TABLE "special" ALTER COLUMN "start_date" SET NOT NULL;
+ALTER TABLE "special" ALTER COLUMN "end_date" SET NOT NULL;


### PR DESCRIPTION
This PR will rework the card generation algorithm to allow any kind of custom template on individual regimes and special events.

A new YAML config file will be introduced in the following provisional format:

```yaml
default:
  canvas: 1500x2000

  background:
    type: image
    size: fill  # base canvas size
    path: "{{ background }}"

  art:
    type: image
    position: 700x261  # top left coordinate
    size: 1359x731  # size rectangle to fit the image in
    path: ".{{ ball.collection_card }}"

  icon:
    type: image
    position: 1200x300
    size: 192x192
    path: "{{ '.'+ball.economy.icon if ball.economy.icon else '' }}"

  description:
    type: text
    position: 50x20
    text: Hi this is a test
    font: mangati.ttf
    size: 80  # text size
    color: "#44FF00FF"  # text color
    stroke:  # text stroke (color+width)
      width: 5
      color: "#FF44FFFF"
    #wrap_width: 32  # width of the text box (wrap new lines)
    align: left  # left/right/middle alignment on position
    spacing: 20  # size between lines if multiline
    #anchor: ms  # where to attach the text base line, used for positioning
    direction: ttb  # right-to-left, left-to-right or top-to-bottom

special_event:  # create an override
  inherit: default
  background:
    # only change the background
    path: something_cool.png
```

Jinja2 templating substitution will be supported to allow a lot of extra stuff.

This implies the removal of the special "shiny" status, which will be automatically replaced by an unlimited special event.

Resolves #435, resolves #5, resolves #17