### PR TITLE
Sort trade view proposal by special rarity

### DIFF
--- a/ballsdex/packages/trade/menu.py
+++ b/ballsdex/packages/trade/menu.py
@@ -639,7 +639,11 @@ class TradeViewMenu(Pages):
         trade_player = (
             trade.trader1 if trade.trader1.user.id == player.discord_id else trade.trader2
         )
-        ball_instances = trade_player.proposal
+
+        ball_instances = sorted(
+            trade_player.proposal,
+            key=lambda ball: ball.specialcard.rarity if ball.specialcard else 1000,
+        )
         if len(ball_instances) == 0:
             return await interaction.followup.send(
                 f"{trade_player.user} has not added any {settings.plural_collectible_name}.",


### PR DESCRIPTION
### Description of the changes

When a user is trading, they want to see the specials at the top of the list (rarest specials first). So, sort the proposal by special, with the rarest special first. 

### Were the changes in this PR tested?

Yes. I don't have a big enough dex to easily test performance, but I don't imagine it's that bad—this is just a couple dict lookups and the rarity should be cached (this is no worse than the random special selection that happens every ball spawn)