### PR TITLE
Allow extra dependencies with `dependencies.txt`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ media
 config.yml
 docker-compose.override.yml
 admin_panel/admin_panel/settings/production.py
+
+# dependencies
+dependencies.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,15 @@ FROM base AS builder-base
 # Pillow build dependencies
 RUN apk add --no-cache gcc libc-dev
 
-COPY poetry.lock pyproject.toml /code/
+COPY poetry.lock pyproject.toml dependencies.txt* /code/
+
 RUN --mount=type=cache,target=/root/.cache/ \
     pip install poetry==2.0.1 && poetry install --no-root
+
+RUN if [ -f dependencies.txt ]; then \
+    poetry run pip install -r dependencies.txt; \
+fi
+
 COPY . /code/
 RUN poetry install
 


### PR DESCRIPTION
### Description of the changes

Allows extra dependencies to be installed in a `dependencies.txt` file.
Very useful for third-party packages that want to use Python libraries that aren't included in the Ballsdex environment without causing conflicts.

### Were the changes in this PR tested?

Yes, below is a list of what I have tested:

- [x] Building and verifying libraries in `dependencies.txt` were installed.
- [x] Using a third-party library (matplotlib) installed from `dependencies.txt` in an external package.
- [x] Building without a `dependencies.txt` file (ignores).