### PR TITLE
Allow logging with webhooks and remove `log_action`

### DIFF
--- a/ballsdex/core/utils/logging.py
+++ b/ballsdex/core/utils/logging.py
@@ -1,22 +1,56 @@
+import asyncio
 import logging
 
+import aiohttp
 import discord
 
-from ballsdex.core.bot import BallsDexBot
 from ballsdex.settings import settings
 
-log = logging.getLogger("ballsdex.packages.admin.cog")
+log = logging.getLogger("ballsdex.core.utils.logging")
 
 
-async def log_action(message: str, bot: BallsDexBot, console_log: bool = False):
-    if settings.log_channel:
-        channel = bot.get_channel(settings.log_channel)
-        if not channel:
-            log.warning(f"Channel {settings.log_channel} not found")
-            return
-        if not isinstance(channel, discord.TextChannel):
-            log.warning(f"Channel {channel.name} is not a text channel")  # type: ignore
-            return
-        await channel.send(message)
-    if console_log:
-        log.info(message)
+class WebhookLoggingHandler(logging.Handler):
+    """
+    Allows messages to be logged to a Discord webhook.
+    """
+
+    def __init__(self, webhook: str):
+        super().__init__(logging.INFO)
+
+        self.webhook = webhook
+
+    async def send_to_webhook(self, message: str):
+        async with aiohttp.ClientSession() as session:
+            try:
+                webhook = discord.Webhook.from_url(self.webhook, session=session)
+                await webhook.send(message, username=f"{settings.bot_name} logging")
+            except Exception:
+                log.error("Failed to send message to webhook", exc_info=True)
+
+    def emit(self, record):
+        try:
+            asyncio.create_task(self.send_to_webhook(self.format(record)))
+        except Exception:
+            self.handleError(record)
+
+
+def webhook_logger(name: str | None = None, webhook_url: str | None = None) -> logging.Logger:
+    """
+    Returns a logger with a `WebhookLoggingHandler` handler.
+
+    Parameters
+    ----------
+    name: str | None
+        The name of the logger.
+    webhook_url: str | None
+        The webhook URL you want to log to. Defaults to `settings.webhook_url`.
+    """
+    new_logger = logging.getLogger(name)
+
+    if webhook_url is None:
+        webhook_url = settings.webhook_url
+
+    if webhook_url is not None:
+        new_logger.addHandler(WebhookLoggingHandler(webhook_url))
+
+    return new_logger

--- a/ballsdex/packages/admin/blacklist.py
+++ b/ballsdex/packages/admin/blacklist.py
@@ -11,10 +11,12 @@ from ballsdex.core.models import (
     GuildConfig,
     Player,
 )
-from ballsdex.core.utils.logging import log_action
+from ballsdex.core.utils.logging import webhook_logger
 from ballsdex.core.utils.paginator import Pages
 from ballsdex.packages.admin.menu import BlacklistViewFormat
 from ballsdex.settings import settings
+
+log = webhook_logger("ballsdex.packages.admin.blacklist")
 
 
 class Blacklist(app_commands.Group):
@@ -59,10 +61,9 @@ class Blacklist(app_commands.Group):
         else:
             interaction.client.blacklist.add(user.id)
             await interaction.response.send_message("User is now blacklisted.", ephemeral=True)
-            await log_action(
+            log.info(
                 f"{interaction.user} blacklisted {user} ({user.id})"
-                f" for the following reason: {reason}.",
-                interaction.client,
+                f" for the following reason: {reason}."
             )
 
     @app_commands.command(name="remove")
@@ -100,10 +101,9 @@ class Blacklist(app_commands.Group):
             await interaction.response.send_message(
                 "User is now removed from blacklist.", ephemeral=True
             )
-            await log_action(
+            log.info(
                 f"{interaction.user} removed blacklist for user {user} ({user.id})."
-                f"\nReason: {reason}",
-                interaction.client,
+                f"\nReason: {reason}"
             )
 
     @app_commands.command(name="info")
@@ -239,10 +239,9 @@ class BlacklistGuild(app_commands.Group):
         else:
             interaction.client.blacklist_guild.add(guild.id)
             await interaction.response.send_message("Guild is now blacklisted.", ephemeral=True)
-            await log_action(
+            log.info(
                 f"{interaction.user} blacklisted the guild {guild}({guild.id}) "
-                f"for the following reason: {reason}.",
-                interaction.client,
+                f"for the following reason: {reason}."
             )
 
     @app_commands.command(name="remove")
@@ -296,10 +295,9 @@ class BlacklistGuild(app_commands.Group):
             await interaction.response.send_message(
                 "Guild is now removed from blacklist.", ephemeral=True
             )
-            await log_action(
+            log.info(
                 f"{interaction.user} removed blacklist for guild {guild} ({guild.id}).\n"
-                f"Reason: {reason}",
-                interaction.client,
+                f"Reason: {reason}"
             )
 
     @app_commands.command(name="info")

--- a/json-config-ref.json
+++ b/json-config-ref.json
@@ -186,14 +186,6 @@
                 }
             }
         },
-        "log-channel": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "description": "ID of the channel to log events to",
-            "$ref": "#/$defs/discord-id"
-        },
         "owners": {
             "type": "object",
             "description": "Manages ownership of the bot",
@@ -274,7 +266,7 @@
                         "string",
                         "null"
                     ],
-                    "description": "Link to a Discord webhook for admin panel notifications",
+                    "description": "Link to a Discord webhook for admin notifications",
                     "pattern": "^https://discord.com/api/webhooks/[0-9]{17,22}/[a-zA-Z0-9-_]{68}$"
                 },
                 "url": {


### PR DESCRIPTION
### Description of the changes

This pull request refactors action logging to support webhook logging instead of channels. It introduces a `webhook_logger` function, which automatically attaches a `WebhookLoggingHandler` handler and returns the `Logger`.

Additionally, since `log-channel` is deprecated, config migrations will automatically remove the variable from the config file in favor of `webhook-url`. It will also send a warning indicating that channel logging is deprecated if `log-channel` is found.

Resolves #655 

### Were the changes in this PR tested?

Yes, below is a list of what I have tested.

- [x] Sending a log using `webhook_logger`.
- [x] Checking if `log-channel` is properly removed if it is detected in the config file.
- [x] Attempting to send a log with an invalid webhook.
- [x] Sending a log without a webhook (only sends through console).
- [x] Sending a log that can't be sent through a webhook, such as an empty message.
