### PR TITLE
Allow emojis in catch messages

### DIFF
--- a/ballsdex/packages/countryballs/countryball.py
+++ b/ballsdex/packages/countryballs/countryball.py
@@ -66,6 +66,7 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
                 collectible=settings.collectible_name,
                 ball=self.view.name,
                 collectibles=settings.plural_collectible_name,
+                emoji=interaction.client.get_emoji(self.view.model.emoji_id),
             )
 
             await interaction.followup.send(
@@ -87,6 +88,7 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
                 ball=self.view.name,
                 collectibles=settings.plural_collectible_name,
                 wrong=wrong_name,
+                emoji=interaction.client.get_emoji(self.view.model.emoji_id),
             )
             await interaction.followup.send(
                 wrong_message,
@@ -264,6 +266,7 @@ class BallSpawnView(View):
                     collectible=settings.collectible_name,
                     ball=self.name,
                     collectibles=settings.plural_collectible_name,
+                    emoji=self.bot.get_emoji(self.model.emoji_id),
                 )
 
                 self.message = await channel.send(
@@ -435,6 +438,7 @@ class BallSpawnView(View):
                 collectible=settings.collectible_name,
                 ball=self.name,
                 collectibles=settings.plural_collectible_name,
+                emoji=self.bot.get_emoji(self.model.emoji_id),
             )
             + " "
         )

--- a/ballsdex/settings.py
+++ b/ballsdex/settings.py
@@ -367,10 +367,14 @@ sentry:
     environment: "production"
 
 catch:
-  # Add any number of messages to each of these categories. The bot will select a random
-  # one each time.
-  # {user} is mention. {collectible} is collectible name. {ball} is ball name, and 
-  # {collectibles} is collectible plural.
+  # Add messages to each category, one is chosen at random each time.
+
+  # KEYWORDS:
+  # - {user} will mention the user.
+  # - {collectible} is the collectible name.
+  # - {collectibles} is the plural collectible name.
+  # - {ball} is the spawned collectible's name
+  # - {emoji} is the collectible's emoji.
 
   # the label shown on the catch button
   catch_button_label: "Catch me!"
@@ -520,10 +524,14 @@ sentry:
     if add_catch_messages:
         content += """
 catch:
-  # Add any number of messages to each of these categories. The bot will select a random
-  # one each time.
-  # {user} is mention. {collectible} is collectible name. {ball} is ball name, and
-  # {collectibles} is collectible plural.
+  # Add messages to each category, one is chosen at random each time.
+
+  # KEYWORDS:
+  # - {user} will mention the user.
+  # - {collectible} is the collectible name.
+  # - {collectibles} is the plural collectible name.
+  # - {ball} is the spawned collectible's name
+  # - {emoji} is the collectible's emoji.
 
   # the label shown on the catch button
   catch_button_label: "Catch me!"


### PR DESCRIPTION
### Description of the changes

Adds support for emojis in catch-related messages.

<img width="319" height="59" alt="example" src="https://github.com/user-attachments/assets/6f45fa06-26a2-4d6e-aa12-69fa2cd878f7" />

### Were the changes in this PR tested?

Yes