### PR TITLE
Fix bug with trades

### DIFF
--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -187,15 +187,13 @@ class Trade(commands.GroupCog):
         blocked = await player1.is_blocked(player2)
         if blocked:
             await interaction.response.send_message(
-                "You cannot begin a trade with a user that you have blocked.",
-                ephemeral=True,
+                "You cannot begin a trade with a user that you have blocked.", ephemeral=True
             )
             return
         blocked2 = await player2.is_blocked(player1)
         if blocked2:
             await interaction.response.send_message(
-                "You cannot begin a trade with a user that has blocked you.",
-                ephemeral=True,
+                "You cannot begin a trade with a user that has blocked you.", ephemeral=True
             )
             return
 
@@ -208,8 +206,7 @@ class Trade(commands.GroupCog):
             return
         if trade2 or trader2:
             await interaction.response.send_message(
-                "The user you are trying to trade with is already in a trade.",
-                ephemeral=True,
+                "The user you are trying to trade with is already in a trade.", ephemeral=True
             )
             return
 
@@ -222,10 +219,7 @@ class Trade(commands.GroupCog):
             return
 
         menu = TradeMenu(
-            self,
-            interaction,
-            TradingUser(interaction.user, player1),
-            TradingUser(user, player2),
+            self, interaction, TradingUser(interaction.user, player1), TradingUser(user, player2)
         )
         self.trades[interaction.guild.id][interaction.channel.id].append(menu)  # type: ignore
         await menu.start()
@@ -398,8 +392,7 @@ class Trade(commands.GroupCog):
             return
         if countryball not in trader.proposal:
             await interaction.response.send_message(
-                f"That {settings.collectible_name} is not in your proposal.",
-                ephemeral=True,
+                f"That {settings.collectible_name} is not in your proposal.", ephemeral=True
             )
             return
         trader.proposal.remove(countryball)
@@ -466,8 +459,7 @@ class Trade(commands.GroupCog):
 
         if days is not None and days < 0:
             await interaction.followup.send(
-                "Invalid number of days. Please provide a non-negative value.",
-                ephemeral=True,
+                "Invalid number of days. Please provide a non-negative value.", ephemeral=True
             )
             return
 

--- a/ballsdex/packages/trade/menu.py
+++ b/ballsdex/packages/trade/menu.py
@@ -159,8 +159,7 @@ class ConfirmView(View):
             return True
 
     @discord.ui.button(
-        style=discord.ButtonStyle.success,
-        emoji="\N{HEAVY CHECK MARK}\N{VARIATION SELECTOR-16}",
+        style=discord.ButtonStyle.success, emoji="\N{HEAVY CHECK MARK}\N{VARIATION SELECTOR-16}"
     )
     async def accept_button(self, interaction: discord.Interaction["BallsDexBot"], button: Button):
         trader = self.trade._get_trader(interaction.user)
@@ -190,13 +189,11 @@ class ConfirmView(View):
                 await interaction.followup.send("The trade is now concluded.", ephemeral=True)
             else:
                 await interaction.followup.send(
-                    ":warning: An error occurred while concluding the trade.",
-                    ephemeral=True,
+                    ":warning: An error occurred while concluding the trade.", ephemeral=True
                 )
         else:
             await interaction.followup.send(
-                "You have accepted the trade, waiting for the other user...",
-                ephemeral=True,
+                "You have accepted the trade, waiting for the other user...", ephemeral=True
             )
 
     @discord.ui.button(
@@ -573,8 +570,7 @@ class CountryballsSelector(Pages):
             else f"{settings.plural_collectible_name}"
         )
         await interaction.followup.send(
-            f"{len(self.balls_selected)} {grammar} added to your proposal.",
-            ephemeral=True,
+            f"{len(self.balls_selected)} {grammar} added to your proposal.", ephemeral=True
         )
         self.balls_selected.clear()
 


### PR DESCRIPTION
### Description of the changes

Fix bug where trade could be cancelled after it had already concluded, which led to a UI issue (the trade still went through though).

Also, make sure to refresh the db for both traders, and wrap the whole trade in a transaction to prevent anything weird from going on (theoretically it only touches the DB in the final loop, but it's better to be safe). I also think ruff reformatted some stuff.

### Were the changes in this PR tested?

Yes