### PR TITLE
Pin postgres to v17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       "
 
   postgres-db:
-    image: postgres
+    image: postgres:17
     restart: always
     hostname: postgres
     shm_size: 1g


### PR DESCRIPTION
### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->
Pin postgres to version 17. Right now, if anyone pulls/tries to set up a new instance of ballsdex, they will be met by a scary "postgres is unhealthy" error and have to troubleshoot it—not ideal.
Unless someone has made local changes to the mountpoint, nobody should have to downgrade postgres, since v18 will not run with the current docker-compose.
Preferring v17 over v18 because I want to limit the amount of hellish postgres major version upgrades necessary.

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yes

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
