### PR TITLE
Add server config status command

### DIFF
--- a/ballsdex/packages/config/cog.py
+++ b/ballsdex/packages/config/cog.py
@@ -124,9 +124,10 @@ class Config(commands.GroupCog):
                         ephemeral=True,
                     )
             else:
+                config_cmd = self.channel.extras.get("mention", "`/config channel`")
                 await interaction.response.send_message(
                     f"{settings.bot_name} is now enabled in this server, however there is no "
-                    "spawning channel set. Please configure one with `/config channel`."
+                    f"spawning channel set. Please configure one with {config_cmd}."
                 )
 
     @app_commands.command()
@@ -136,13 +137,20 @@ class Config(commands.GroupCog):
         Check the server configuration status.
         """
         config = await GuildConfig.get_or_none(guild_id=interaction.guild_id)
+        config_cmd = self.channel.extras.get("mention", "`/config channel`")
         if not config or not config.spawn_channel:
             await interaction.response.send_message(
                 f"{settings.bot_name} is not configured in this server yet.\n"
-                "Please use `/config channel` to set a channel.",
+                f"Please use {config_cmd} to set a channel.",
                 ephemeral=False,
             )
         else:
+            assert interaction.guild
+            if interaction.guild.unavailable:
+                await interaction.response.send_message(
+                    "Your server is unavailable to the bot. Readding it may fix this."
+                )
+                return
             channel = interaction.guild.get_channel(config.spawn_channel)
             if channel:
                 await interaction.response.send_message(
@@ -155,6 +163,6 @@ class Config(commands.GroupCog):
                 await interaction.response.send_message(
                     f"{settings.bot_name} is configured, but the specified channel "
                     "could not be found.\n"
-                    "Please use `/config channel` to set it again.",
+                    f"Please use {config_cmd} to set it again.",
                     ephemeral=False,
                 )


### PR DESCRIPTION
### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->
Add a new command in config pack, allowing user to check whether the server has configured or not.

Newcomers are spared the temptation to tinker with channel settings, having no choice but to repeatedly restart to verify whether the configuration has succeeded.


### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yes

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
