### PR TITLE
Add an explicit catch_date before querying db

### DIFF
--- a/ballsdex/packages/countryballs/countryball.py
+++ b/ballsdex/packages/countryballs/countryball.py
@@ -349,6 +349,7 @@ class BallSpawnView(View):
             raise RuntimeError("This ball was already caught!")
         self.caught = True
         self.catch_button.disabled = True
+        caught_time = tortoise_now()
         player = player or (await Player.get_or_create(discord_id=user.id))[0]
         is_new = not await BallInstance.filter(player=player, ball=self.model).exists()
 
@@ -391,6 +392,7 @@ class BallSpawnView(View):
             health_bonus=bonus_health,
             server_id=guild.id if guild else None,
             spawned_time=self.message.created_at,
+            catch_date=caught_time,
         )
 
         # logging and stats


### PR DESCRIPTION
### Description of the changes
Adds an explicit call to catch_date when creating the ball with a time when the item was caught to give a better and more accurate catch time instead of after multiple stuff is queried

### Were the changes in this PR tested?

No

