### PR TITLE
Add info about catch time

### DIFF
--- a/ballsdex/core/models.py
+++ b/ballsdex/core/models.py
@@ -386,11 +386,6 @@ class BallInstance(models.Model):
             else None
         )
 
-        if isinstance(catch_time, timedelta) and not 0 < catch_time.total_seconds() < 60 * 30:
-            # some balls have a negative timedelta because of tz stuff,
-            # or if it's greater than 30 minutes, the view would have expired,
-            catch_time = None
-
         catch_time_msg = f" in {catch_time.total_seconds():.3f}s" if catch_time else ""
 
         content = (


### PR DESCRIPTION
### Description of the changes

Adds info about catch time in the /balls info view. Also works on list, last, anything that uses prepare_for_message really.

<img width="703" height="520" alt="image" src="https://github.com/user-attachments/assets/c83046da-53c3-46ba-905d-b2974a1c26fd" />

This could be done in one giant ternary but I think that would look a little ugly, so even though this is more verbose I prefer it.

I don't think there's any harm in showing the users this info. Rounded to 3 decimal places, that seems sufficient to me. It shows nothing if the info isn't found or if the timedelta is broken.

### Were the changes in this PR tested?

Yes