### PR TITLE
Fix `user` -> `trade_user` typo in trade history

### DIFF
--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -220,7 +220,7 @@ class Trade(commands.GroupCog):
         try:
             p1 = await Player.objects.only("id").aget(discord_id=user.id)
             if trade_user:
-                p2 = await Player.objects.only("id").aget(discord_id=user.id)
+                p2 = await Player.objects.only("id").aget(discord_id=trade_user.id)
         except Player.DoesNotExist:
             await interaction.response.send_message("One of the players does not exist.", ephemeral=True)
             return


### PR DESCRIPTION
Otherwise p1 and p2 are the same which I think was not intended.

### Were the changes in this PR tested?

No