### PR TITLE
Pin postgres-backup to v18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,7 +157,7 @@ services:
       retries: 5
 
   postgres-backup:
-    image: prodrigestivill/postgres-backup-local
+    image: prodrigestivill/postgres-backup-local:18-alpine-d257e5d
     restart: always
     # Uncomment to have the backup files owned by your local user instead of root
     # user: username


### PR DESCRIPTION
### Description of the changes
Pins postgres-backup to v18. Fixes bug where mismatch between postgres and backup versions breaks backups silently.
<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->

### Were the changes in this PR tested?
No
