### PR TITLE
Add `/admin balls collection`

### DIFF
--- a/ballsdex/packages/admin/flags.py
+++ b/ballsdex/packages/admin/flags.py
@@ -47,9 +47,13 @@ class GiveBallFlags(FlagConverter):
 
 class BallsCountFlags(FlagConverter):
     user: discord.User | None = flag(description="The player whose countryballs you are counting")
-    countryball: BallTransform | None = flag(description="Restrict countring to a specific countryball")
+    countryball: BallTransform | None = flag(description="Restrict counting to a specific countryball")
     special: SpecialTransform | None = flag(description="Restrict counting to a special event")
     deleted: bool = flag(default=False, description="Count the deleted countryballs too")
+
+
+class BallsCollectionFlags(FlagConverter):
+    countryball: BallTransform | None = flag(description="The countryball you want to filter by.")
 
 
 class TradeHistoryFlags(FlagConverter):


### PR DESCRIPTION
## Admin Balls Collection

Adds a `/admin balls collection` command which allows admins to view how many balls exist along with the ball's special count for every special.

[This command was suggested](https://discordapp.com/channels/1255250024741212262/1437116382931189933)

### Images

<img width="551" height="712" alt="example1" src="https://github.com/user-attachments/assets/f601f8c3-9970-453d-bcd7-a1bc22136a21" />
<img width="543" height="717" alt="example2" src="https://github.com/user-attachments/assets/775b634c-2ce8-4e12-bb04-33af90fc49f8" />

### Were the changes in this PR tested?

Yes (except for seeing if the trade count is accurate, but it most likely is)