### PR TITLE
Improve queryset ordering for deterministic results

### DIFF
--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -174,7 +174,7 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         if sort:
             query = sort_balls(sort, query)
         else:
-            query = query.order_by("-favorite")
+            query = query.order_by("-favorite", "-id")
 
         if not await query.aexists():
             ball_txt = countryball.country if countryball else ""
@@ -694,7 +694,7 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         query = (
             queryset.values(annotations["value_id"].name)
             .annotate(**annotations, count=Count("value_id"))
-            .order_by("-count")
+            .order_by("-count", "name")
         )
 
         if apply_limit and limit is not None:

--- a/ballsdex/packages/balls/countryballs_paginator.py
+++ b/ballsdex/packages/balls/countryballs_paginator.py
@@ -55,7 +55,7 @@ class CountryballsDuplicateSource(LayoutView):
                 .prefetch_related("ball")
                 .values("ball__country")
                 .annotate(count=Count("ball__country"))
-                .order_by("-count")
+                .order_by("-count", "ball__country")
             )
         else:
             countryball = await Ball.objects.aget(id=select.values[0])
@@ -73,7 +73,7 @@ class CountryballsDuplicateSource(LayoutView):
                 .exclude(special__hidden=True)
                 .values("special__name")
                 .annotate(count=Count("special__name"))
-                .order_by("-count")
+                .order_by("-count", "special__name")
             )
 
         counts = await balls_query.values("total", "traded", "specials").aget()


### PR DESCRIPTION
### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->
Fixed balls jumping around between pages. I added a secondary sort key (like -id or name) to sorting.py, the main list command, and the paginator. This stops the order from shuffling when stats or counts are the same.

[bug report](https://discord.com/channels/1049118743101452329/1460422979526852608)

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
