### PR TITLE
docs: update copyright year to 2026 in mkdocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_name: Ballsdex Discord bot
 site_url: https://wiki.ballsdex.com
 repo_url: https://github.com/Ballsdex-Team/BallsDex-DiscordBot
 
-copyright: Copyright &copy; 2022 - 2025 Auguste "El Laggron" Charpentier
+copyright: Copyright &copy; 2022 - 2026 Auguste "El Laggron" Charpentier
 
 theme:
   name: material


### PR DESCRIPTION
### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->
was poking around the site and noticed the copyright year is still 2025

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yeah

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
