### PR TITLE
Fix "this server" filter in /balls completion command

### DIFF
--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -274,7 +274,7 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
             }
 
         if filter:
-            query = filter_balls(filter, BallInstance.objects.filter(**filters))
+            query = filter_balls(filter, BallInstance.objects.filter(**filters), interaction.guild_id)
         else:
             query = BallInstance.objects.filter(**filters)
 


### PR DESCRIPTION
### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->
Fixes an issue where the `this server` filter in the `/balls completion` command was being silently ignored because the `guild_id` was not passed to the filter_balls utility.

Thanks to Discord user **james_redstone** for bringing this issue up.

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
