### PR TITLE
Fix db side stats calculation

### DIFF
--- a/admin_panel/bd_models/models.py
+++ b/admin_panel/bd_models/models.py
@@ -213,8 +213,22 @@ class SpecialEnabledManager(Manager["Special"]):
 class BaseBallInstanceManager[T: models.Model](Manager[T]):
     def with_stats(self):
         return self.annotate(
-            attack=Cast(F("attack_bonus"), models.BigIntegerField()) * F("ball__attack"),
-            health=Cast(F("health_bonus"), models.BigIntegerField()) * F("ball__health"),
+            attack=Cast(
+                models.ExpressionWrapper(
+                    F("ball__attack")
+                    * (models.Value(1.0) + Cast(F("attack_bonus"), models.FloatField()) / models.Value(100.0)),
+                    output_field=models.FloatField(),
+                ),
+                models.BigIntegerField(),
+            ),
+            health=Cast(
+                models.ExpressionWrapper(
+                    F("ball__health")
+                    * (models.Value(1.0) + Cast(F("health_bonus"), models.FloatField()) / models.Value(100.0)),
+                    output_field=models.FloatField(),
+                ),
+                models.BigIntegerField(),
+            ),
         )
 
 


### PR DESCRIPTION
### Description of the changes

Fixes the DB side stats calculation (was using (bonus * base stat) instead of ((1+bonus/100) * base stat), as laid out in [this](https://discord.com/channels/1049118743101452329/1469117041901572363) very nice bug report.

As far as I can tell, this only effects data export.

### Were the changes in this PR tested?

Yes