### PR TITLE
Fix crash when resetting trade proposal

### DIFF
--- a/ballsdex/packages/trade/trade.py
+++ b/ballsdex/packages/trade/trade.py
@@ -365,7 +365,7 @@ class TradingUser(Container):
             raise AlreadyLockedError()
         if self.view.cancelled:
             raise CancelledError()
-        await self.get_queryset().aupdate(locked=False)
+        await self.get_queryset().aupdate(locked=None)
         self.proposal.clear()
 
     async def cancel(self):
@@ -486,7 +486,7 @@ class TradeInstance(LayoutView):
         except TradeError as e:
             await interaction.followup.send(e.error_message, ephemeral=True)
         else:
-            await self.edit_message(interaction)
+            await self.edit_message(None)
 
     @buttons.button(
         label="Cancel trade",


### PR DESCRIPTION
### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->

DB TypeError: Changed `locked=False` to `locked=None` (field is `DateTimeField`).
UI Error: Issues identified during testing, prevents editing the ephemeral confirmation message by passing `None` to `edit_message`.

[bug report here](https://discord.com/channels/1049118743101452329/1469619477581664257)

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yes

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
