### PR TITLE
Reimplement admin channel ids for inv privacy bypass

### DIFF
--- a/admin_panel/settings/models.py
+++ b/admin_panel/settings/models.py
@@ -119,12 +119,17 @@ class Settings(models.Model):
 
     # admin command control
     admin_channel_ids = models.TextField(
-        help_text="Semicolon-delimited list of channel IDs where admin commands can be used. Ignored for owners. "
+        help_text="Semicolon-delimited channel IDs where staff may bypass inventory privacy. Ignored for owners."
         "If empty, then admin commands can be used everywhere.",
         validators=(RegexValidator(COLON_IDS_RE, message="The IDs must be semicolon-separated"),),
         blank=True,
         default="",
     )
+
+    @cached_property
+    def inv_privacy_bypass_ids(self) -> list[int]:
+        return [] if self.admin_channel_ids is None else [int(x) for x in self.admin_channel_ids.split(";") if x]
+
     webhook_logging = models.URLField(
         help_text="An optional Discord Webhook where admin events will be logged.",
         validators=(RegexValidator(DISCORD_WEBHOOK_RE, message="Only Discord webhooks are supported."),),

--- a/ballsdex/core/utils/utils.py
+++ b/ballsdex/core/utils/utils.py
@@ -4,6 +4,7 @@ import discord
 
 from bd_models.enums import PrivacyPolicy
 from bd_models.models import Player
+from settings.models import settings
 
 from .checks import get_user_for_check
 
@@ -35,6 +36,7 @@ async def is_staff(interaction: discord.Interaction["BallsDexBot"], *perms: str)
         return user
     if not user.is_staff:
         return False
+
     return await user.ahas_perms(perms)
 
 
@@ -70,7 +72,9 @@ async def inventory_privacy(
     if interaction.user.id == player.discord_id:
         return True
     if await is_staff(interaction):
-        return True
+        if settings.inv_privacy_bypass_ids and interaction.channel_id in settings.inv_privacy_bypass_ids:
+            return True
+
     if privacy_policy == PrivacyPolicy.DENY:
         await interaction.followup.send("This user has set their inventory to private.", ephemeral=True)
         return False


### PR DESCRIPTION
### Description of the changes

Fixes a regression in v3 where admin channel inv privacy bypass ids had no effect. 

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yes

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
