### PR TITLE
[trade] Add optional special filters for add and remove commands in trade

### DIFF
--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -149,7 +149,12 @@ class Trade(commands.GroupCog):
             await interaction.followup.send("The trade has started.", ephemeral=True)
 
     @app_commands.command(extras={"trade": TradeCommandType.PICK})
-    async def add(self, interaction: Interaction, countryball: BallInstanceTransform):
+    async def add(
+        self,
+        interaction: Interaction,
+        countryball: BallInstanceTransform,
+        special: SpecialEnabledTransform | None = None,
+    ):
         """
         Add a countryball to your trade proposal. You must have a trade open.
 
@@ -157,6 +162,8 @@ class Trade(commands.GroupCog):
         ----------
         countryball: BallInstance
             The countryball you are adding to your trade.
+        special: Special | None
+            The special you want to filter the countryball by.
         """
         result = await self.get_trade(interaction)
         if result is None:

--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -181,7 +181,12 @@ class Trade(commands.GroupCog):
             )
 
     @app_commands.command(extras={"trade": TradeCommandType.REMOVE})
-    async def remove(self, interaction: Interaction, countryball: BallInstanceTransform):
+    async def remove(
+        self,
+        interaction: Interaction,
+        countryball: BallInstanceTransform,
+        special: SpecialEnabledTransform | None = None,
+    ):
         """
         Remove a countryball from your trade proposal. You must have a trade open.
 
@@ -189,6 +194,8 @@ class Trade(commands.GroupCog):
         ----------
         countryball: BallInstance
             The countryball you are removing from your trade.
+        special: Special | None
+            The special you want to filter the countryball by.
         """
         result = await self.get_trade(interaction)
         if result is None:


### PR DESCRIPTION
### Description of the changes

This pull request updates the `add` and `remove` trade commands to support an optional `special` filter parameter, allowing users to specify a particular special attribute when adding or removing a countryball from a trade.

Enhancements to trade commands:

* Added an optional `special` parameter of type `SpecialEnabledTransform | None` to the `add` command, enabling users to filter the countryball by a special attribute when adding it to a trade.
* Added an optional `special` parameter of type `SpecialEnabledTransform | None` to the `remove` command, enabling users to filter the countryball by a special attribute when removing it from a trade.