### PR TITLE
Show spawn art for duplicate collection to match collection

### DIFF
--- a/ballsdex/packages/balls/countryballs_paginator.py
+++ b/ballsdex/packages/balls/countryballs_paginator.py
@@ -103,7 +103,9 @@ class CountryballsDuplicateSource(LayoutView):
         embed = discord.Embed(title=f"{name} Collection", description=desc, color=discord.Color.blurple())
         embed.set_author(name=interaction.user.display_name, icon_url=interaction.user.display_avatar.url)
         if countryball:
-            emoji = interaction.client.get_emoji(countryball.emoji_id)
-            if emoji:
-                embed.set_thumbnail(url=emoji.url)
-        await interaction.followup.send(embed=embed)
+            file_location = countryball.wild_card.path
+            file = discord.File(file_location, filename="countryball.png")
+            embed.set_thumbnail(url="attachment://countryball.png")
+            await interaction.followup.send(embed=embed, file=file)
+        else:
+            await interaction.followup.send(embed=embed)


### PR DESCRIPTION
### Description of the changes

Show spawn art for duplicate collection instead of emoji, for parity with regular collection. (see [report](https://discord.com/channels/1049118743101452329/1484307681937326281))

It's a little icky that this code is duplicated, but I didn't want to refactor it rn.

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.
To answer, add an "x" in between the square brackets [x] for the option you want to choose. 

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
- [x] Yes
- [ ] No
