### PR TITLE
Add media check command

### DIFF
--- a/admin_panel/bd_models/models.py
+++ b/admin_panel/bd_models/models.py
@@ -254,9 +254,7 @@ class Special(models.Model):
         blank=True, null=True, help_text="End time of the event. If blank, the event is permanent"
     )
     rarity = models.FloatField(help_text="Value between 0 and 1, chances of using this special background.")
-    emoji = models.CharField(
-        max_length=20, blank=True, null=True, help_text="Either a unicode character or a discord emoji ID"
-    )
+    emoji = models.CharField(max_length=20, blank=True, null=True, help_text="A unicode character")
     background = models.ImageField(max_length=200, blank=True, null=True, help_text="1428x2000 PNG image")
     tradeable = models.BooleanField(help_text="Whether balls of this event can be traded", default=True)
     hidden = models.BooleanField(help_text="Hides the event from user commands", default=False)

--- a/ballsdex/core/commands.py
+++ b/ballsdex/core/commands.py
@@ -12,7 +12,7 @@ from ballsdex.core.dev import send_interactive
 from ballsdex.core.discord import LayoutView, View
 from ballsdex.core.utils.formatting import pagify
 from ballsdex.core.utils.menus import Menu, TextFormatter, TextSource
-from bd_models.models import Ball, Special
+from bd_models.models import Ball
 from settings.models import load_settings, settings
 
 log = logging.getLogger("ballsdex.core.commands")
@@ -148,19 +148,6 @@ class Core(commands.Cog):
                 continue
 
             lines.append(f" - Ball `{ball.country}` has a broken emoji")
-
-        specials = Special.objects.all()
-        async for special in specials:
-            if not special.emoji:
-                continue
-
-            if not special.emoji.isdigit():
-                continue
-
-            if self.bot.get_emoji(int(special.emoji)):
-                continue
-
-            lines.append(f" - Special `{special.name}` has a broken emoji")
 
         lines.append("# Broken media:")
         for ball in balls:

--- a/ballsdex/core/commands.py
+++ b/ballsdex/core/commands.py
@@ -12,7 +12,7 @@ from ballsdex.core.dev import send_interactive
 from ballsdex.core.discord import LayoutView, View
 from ballsdex.core.utils.formatting import pagify
 from ballsdex.core.utils.menus import Menu, TextFormatter, TextSource
-from bd_models.models import Ball
+from bd_models.models import Ball, Special
 from settings.models import load_settings, settings
 
 log = logging.getLogger("ballsdex.core.commands")
@@ -131,6 +131,48 @@ class Core(commands.Cog):
 
         delta = await wrapper()
         await ctx.send(f"Analyzed database in {round(delta * 1000)}ms.")
+
+    @commands.command()
+    @commands.is_owner()
+    async def checkmedia(self, ctx: commands.Context):
+        """
+        Check collectible media filesizes and emoji ids
+        """
+
+        lines = []
+        lines.append("# Missing emojis:")
+        balls = [ball async for ball in Ball.objects.all()]
+
+        for ball in balls:
+            if self.bot.get_emoji(ball.emoji_id):
+                continue
+
+            lines.append(f" - Ball `{ball.country}` has a broken emoji")
+
+        specials = Special.objects.all()
+        async for special in specials:
+            if not special.emoji:
+                continue
+
+            if not special.emoji.isdigit():
+                continue
+
+            if self.bot.get_emoji(int(special.emoji)):
+                continue
+
+            lines.append(f" - Special `{special.name}` has a broken emoji")
+
+        lines.append("# Broken media:")
+        for ball in balls:
+            if not ball.wild_card.storage.exists(ball.wild_card.name):
+                lines.append(f" - Spawn image for `{ball.country}` is missing")
+            if not ball.collection_card.storage.exists(ball.collection_card.name):
+                lines.append(f" - Collection card for `{ball.country}` is missing")
+            if ball.wild_card.size > 8 * (10**6):
+                lines.append(f" - Spawn image for `{ball.country}` is {ball.wild_card.size // 10**6}MB")
+
+        pages = pagify("\n".join(lines), delims=["###", "\n\n", "\n"], priority=True)
+        await send_interactive(ctx, pages, block=None)
 
     @commands.command()
     @commands.is_owner()


### PR DESCRIPTION
### Description of the changes
Adds a owner command `{prefix}.checkmedia` for fixing broken states / identifying spawn errors.

Inspired by the hundreds of patreon dexes with broken emojis.
Also checks spawn image size / presence.

Sample:
<img width="475" height="245" alt="image" src="https://github.com/user-attachments/assets/91b9d78b-f6f2-41cc-937a-464fc6df0abb" />

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.
To answer, add an "x" in between the square brackets [x] for the option you want to choose. 

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
- [x] Yes
- [ ] No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
