### PR TITLE
[Bugfix] New trade system doesnt respect player mention settings

### DIFF
--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -20,6 +20,7 @@ from ballsdex.core.utils.transformers import (
     SpecialEnabledTransform,
     TradeCommandType,
 )
+from ballsdex.core.utils.utils import can_mention
 from bd_models.models import BallInstance, Player
 from bd_models.models import Trade as TradeModel
 from settings.models import settings
@@ -138,7 +139,10 @@ class Trade(commands.GroupCog):
         try:
             await trade.trader1.refresh_container()
             await trade.trader2.refresh_container()
-            trade.message = await interaction.channel.send(view=trade)  # type: ignore
+            trade.message = await interaction.channel.send(
+                view=trade,
+                allowed_mentions=await can_mention([player1, player2])
+            )  # type: ignore
         except Exception:
             # unregister the trade if something failed to avoid the 30 min timeout
             del self.trades[interaction.channel.id][interaction.user.id]

--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -139,10 +139,9 @@ class Trade(commands.GroupCog):
         try:
             await trade.trader1.refresh_container()
             await trade.trader2.refresh_container()
-            trade.message = await interaction.channel.send(
-                view=trade,
-                allowed_mentions=await can_mention([player1, player2])
-            )  # type: ignore
+            trade.message = await interaction.channel.send(  # type: ignore
+                view=trade, allowed_mentions=await can_mention([player1, player2])
+            )
         except Exception:
             # unregister the trade if something failed to avoid the 30 min timeout
             del self.trades[interaction.channel.id][interaction.user.id]


### PR DESCRIPTION

## Description of the changes
The trade system didn't respect player mention settings when a trade was created, resulting in unwanted pings. This PR updates [ballsdex/packages/trade/cog.py](code-assist-path:c:\Users\tvpre\Documents\code\BallsDex-DiscordBot\ballsdex\packages\trade\cog.py) to use allowed_mentions utilizing the can_mention utility when sending the initial trade message, ensuring that players with their mention policy set to "no mentions" are no longer pinged.

Were the changes in this PR tested?
[x] Yes
[ ] No