### PR TITLE
fix wrong page number in all v2 components

### DIFF
--- a/ballsdex/core/utils/menus/menus.py
+++ b/ballsdex/core/utils/menus/menus.py
@@ -233,6 +233,7 @@ class Menu[P]:
             self.controls._parent = container
 
     async def set_page(self, page: int):
+        self.current_page = page
         p = await self.source.get_page(page)
         for formatter in self.formatters:
             await formatter.format_page(p)


### PR DESCRIPTION
### Description of the changes

In set_page, the formatters run before edit_buttons sets self.menu.current_page = page, so ItemFormatter reads the stale (previous) page number.

### Were the changes in this PR tested?

No
