### PR TITLE
Allow superuser to always bypass inv privacy

### DIFF
--- a/ballsdex/core/utils/utils.py
+++ b/ballsdex/core/utils/utils.py
@@ -71,8 +71,12 @@ async def inventory_privacy(
     interacting_player, _ = await Player.objects.aget_or_create(discord_id=interaction.user.id)
     if interaction.user.id == player.discord_id:
         return True
-    if await is_staff(interaction):
+
+    staff = await is_staff(interaction)
+    if staff:
         if settings.inv_privacy_bypass_ids and interaction.channel_id in settings.inv_privacy_bypass_ids:
+            return True
+        elif staff is True:  # only possible when user is superuser
             return True
 
     if privacy_policy == PrivacyPolicy.DENY:


### PR DESCRIPTION
### Description of the changes

Fixes a regression in #734 where superusers could only bypass inv privacy in set channels.

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.
To answer, add an "x" in between the square brackets [x] for the option you want to choose. 

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
- [x] Yes
- [ ] No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
