### PR TITLE
[about] Fix "3rd party packages" not working when u click a package with hyphens in their name

### DIFF
--- a/ballsdex/packages/info/license.py
+++ b/ballsdex/packages/info/license.py
@@ -16,7 +16,8 @@ packages = importlib.metadata.packages_distributions()
 extra_apps_dist: dict[str, importlib.metadata.Distribution] = {}
 for app in settings.EXTRA_APPS:
     try:
-        extra_apps_dist[app] = importlib.metadata.distribution(packages[app][0])
+        dist = importlib.metadata.distribution(packages[app][0])
+        extra_apps_dist[dist.name] = dist
     except (KeyError, IndexError):
         pass
 


### PR DESCRIPTION
### Description of the changes
this fixes the error that would occur if a package had hyphens in its name
### Were the changes in this PR tested?
- [x] Yes
- [ ] No