### PR TITLE
Fix libraqm versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ ENV PYTHONFAULTHANDLER=1 \
     DJANGO_SETTINGS_MODULE=admin_panel.settings
 
 # Pillow runtime dependencies
-# TODO: remove testing repository when alpine 3.22 is released (libraqm is only on edge for now)
-RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community libraqm-dev && \
+# TODO: remove edge repository when alpine 3.24 is released (postgresql18-client is only on edge for now)
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.23/community libraqm-dev && \
     apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main postgresql18-client && \
     apk add --no-cache tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev \
     lcms2-dev libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev \


### PR DESCRIPTION
### Description of the changes

Change `edge` to `v3.23` because libraqm-dev has moved off edge. We can't just bump alpine yet because python isn't out for alpine 3.23.

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.
To answer, add an "x" in between the square brackets [x] for the option you want to choose. 

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
- [x] Yes
- [ ] No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
