### PR TITLE
Doc improvements: add multiple bot host guide & use management cmd for yml import

### DIFF
--- a/docs/selfhosting/misc/hosting-multiple-bots.md
+++ b/docs/selfhosting/misc/hosting-multiple-bots.md
@@ -1,0 +1,36 @@
+Hosting multiple bots on one machine is very similar to hosting one.
+
+First, enter a Linux terminal (WSL or proper linux).
+
+## 1. Download the bot
+Clone Ballsdex. **You must replace <botname>** with some text you haven't already used for another bot (the dex's name is a decent choice)
+
+```bash
+git clone https://github.com/laggron42/BallsDex-DiscordBot.git <botname>
+```
+
+Then, run `cd <botname>` (replacing <botname> with whatever you chose). Like with one bot, every time you need to type commands for a dex, you must always open the bot's directory first.
+
+## 2. Change the port
+If you do not change the port for the new bot, they will collide and the new bot won't be able to run.
+
+Create a file with the name `docker-compose.override.yml` using this command:
+```bash
+touch docker-compose.override.yml
+```
+
+Using an editor of your choice, open the file and insert:
+```yaml
+services:
+  proxy:
+    ports: !override
+      - "127.0.0.1:8001:80"
+```
+
+If you are running a 3rd or even more bots, change `8001` to `8000+number of bots` or just pick a number you haven't used yet.
+
+!!! info
+    You may have seen some people suggesting editing the docker-compose.yml to change the port. While this will work, using an override is better because then the git tree is clean (`docker-compose.override.yml` is gitignored)
+
+## 3. Setting up the bot
+From here, the process is the same as with a normal bot. Continue with [the rest of the tutorial](../installation/installing-ballsdex.md#4-installing-the-bot).

--- a/docs/selfhosting/misc/hosting-multiple-bots.md
+++ b/docs/selfhosting/misc/hosting-multiple-bots.md
@@ -11,6 +11,9 @@ git clone https://github.com/laggron42/BallsDex-DiscordBot.git <botname>
 
 Then, run `cd <botname>` (replacing <botname> with whatever you chose). Like with one bot, every time you need to type commands for a dex, you must always open the bot's directory first.
 
+!!! warning
+    You must not change your bot's folders name after installation. Doing so will result in your dex being unable to find your config and data.
+
 ## 2. Change the port
 If you do not change the port for the new bot, they will collide and the new bot won't be able to run.
 

--- a/docs/selfhosting/misc/upgrading-to-3.0.md
+++ b/docs/selfhosting/misc/upgrading-to-3.0.md
@@ -196,9 +196,7 @@ docker compose down --volumes
 Ballsdex 3.0 does not use `config.yml` anymore for its configuration, instead it's all on the
 admin panel. You can still import your old settings.
 
-1.  [Create a local admin account](/selfhosting/admin-panel/getting-started/).
-    Remember that all admin accounts were lost in the process, you have to recreate one.
-2.  Start the admin panel
+1.  Start the admin panel
 
     === "With Docker"
 
@@ -239,11 +237,22 @@ admin panel. You can still import your old settings.
 
             You will have to find a solution later to expose the static files yourself.
 
-3.  Open [the new settings page](http://localhost:8000/settings/settings/)
-4.  Tick the checkbox next to "Global bot settings"
-5.  In the "Action" drop-down, select "Import YAML settings" and click "Go"
-6.  Choose the `config.yml` file to upload, and continue
-7.  Verify that all the settings were imported as intended.
+2. Import your settings
+
+   === "With Docker"
+
+       ```bash
+       cat config.yml | docker compose exec -iT admin-panel python3 -m django import_settings_yml
+       ```
+
+   === "Without Docker"
+       
+       ```bash
+       DJANGO_SETTINGS_MODULE=admin_panel.settings python3 -m django import_settings_yml config.yml
+       ```
+
+2.  If not using Oauth2, [Create a local admin account](/selfhosting/admin-panel/getting-started/).
+Remember that all admin accounts were lost in the process, you have to recreate one.
 
 !!! warning
     This will override settings you have previously configured here.


### PR DESCRIPTION
### Description of the changes

Add a guide for multiple bot hosting, and switch to using the management command (rather than importing a file from the panel) for v3 upgrades since it's a little cleaner and doesn't require a local admin account if you're already using oauth2.

### Were the changes in this PR tested?

They're docs. But the commands in question are the ones I use to manage patreon hosts, so they should work.

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
