### PR TITLE
Make prompt messages their own section to support lots of them

### DIFF
--- a/admin_panel/settings/admin.py
+++ b/admin_panel/settings/admin.py
@@ -20,19 +20,33 @@ class YAMLImportForm(AdminActionForm):
     file = forms.FileField(widget=forms.ClearableFileInput(attrs={"accept": ".yml,.yaml"}), allow_empty_file=False)
 
 
-class PromptInline(admin.TabularInline):
-    model = PromptMessage
+@admin.register(PromptMessage)
+class PromptMessageAdmin(admin.ModelAdmin):
     formfield_overrides = {models.TextField: {"widget": widgets.Textarea({"rows": 2, "cols": 60})}}
-    extra = 0
-    classes = ("collapse",)
-    ordering = ("category",)
+
+    list_display = ("category", "message", "rarity")
+    list_editable = ("category", "message", "rarity")
+
+    list_filter = ("category",)
+    exclude = ("settings", "id")
+
+    # otherwise, category is link
+    list_display_links = None
+
+    search_fields = ("message",)
+
+    list_per_page = 100
+
+    def save_model(self, request, obj, form, change):
+        if obj.settings_id is None:
+            obj.settings = Settings.objects.first()
+        super().save_model(request, obj, form, change)
 
 
 @admin.register(Settings)
 class SettingsAdmin(admin.ModelAdmin):
     save_on_top = True
     formfield_overrides = {models.TextField: {"widget": widgets.TextInput}}
-    inlines = (PromptInline,)
     fieldsets = [
         (None, {"fields": ("bot_token", "prefix")}),
         (

--- a/admin_panel/settings/admin.py
+++ b/admin_panel/settings/admin.py
@@ -22,6 +22,13 @@ class YAMLImportForm(AdminActionForm):
 
 @admin.register(PromptMessage)
 class PromptMessageAdmin(admin.ModelAdmin):
+    search_help_text = """{user} will mention the user.
+{collectible} is the collectible name.
+{collectibles} is the plural collectible name.
+{ball} is the spawned collectible's name
+{emoji} is the collectible's emoji.
+{wrong} is what the user put for a wrong message"""
+
     formfield_overrides = {models.TextField: {"widget": widgets.Textarea({"rows": 2, "cols": 60})}}
 
     list_display = ("category", "message", "rarity")


### PR DESCRIPTION
### Description of the changes

Resolves #762 

The UX is IMO roughly the same; everything is editable inline, you save and then `@botping reloadconf` to apply, etc.

The only major difference is that a) it's not in the settings model changeview and b) deleting now needs to be done with the actions at the top (but you can do it in bulk now also, so it's not bad).

### Were the changes in this PR tested?

Yes
<img width="1413" height="841" alt="image" src="https://github.com/user-attachments/assets/08240964-470e-4e5a-8056-0184081b0361" />

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
