### PR TITLE
Unify prompt message handling

### DIFF
--- a/admin_panel/settings/models.py
+++ b/admin_panel/settings/models.py
@@ -14,6 +14,10 @@ from django.dispatch import receiver
 from django.forms import ValidationError
 from django.utils.functional import cached_property
 
+if TYPE_CHECKING:
+    from ballsdex.core.bot import BallsDexBot
+    from bd_models.models import Ball
+
 COLON_IDS_RE = re.compile(r"^(\d{17,21}(;\d{17,21})*)?$")
 SLASH_COMMAND_RE = re.compile(r"^[-_'\S]{1,32}$")
 DISCORD_INVITE_RE = re.compile(r"^https?://(discord.gg|discord(app)?.com/invite)/[a-zA-Z0-9]+$")
@@ -225,6 +229,22 @@ class Settings(models.Model):
                     population=list(self.slow_messages.keys()), weights=list(self.slow_messages.values()), k=1
                 )[0]
 
+    def get_formatted_message(
+        self, category: PromptMessage.PromptType, model: Ball, mention: str, bot: BallsDexBot, **kwargs: str
+    ):
+        message = self.get_random_message(category)
+        try:
+            return message.format(
+                user=mention,
+                ball=model.country,
+                emoji=bot.get_emoji(model.emoji_id),
+                collectible=self.collectible_name,
+                collectibles=self.plural_collectible_name,
+                **kwargs,
+            )
+        except ValueError, IndexError, KeyError:
+            return message
+
     @property
     @warnings.deprecated("This setting returns nothing, Webhook notifications must be used instead")
     def log_channel(self):
@@ -273,7 +293,7 @@ class PromptMessage(models.Model):
         )
 
     def __str__(self) -> str:
-        return ""
+        return self.message
 
 
 @receiver(post_init, sender=Settings)

--- a/admin_panel/settings/models.py
+++ b/admin_panel/settings/models.py
@@ -242,7 +242,7 @@ class Settings(models.Model):
                 collectibles=self.plural_collectible_name,
                 **kwargs,
             )
-        except ValueError, IndexError, KeyError:
+        except (ValueError, IndexError, KeyError):
             return message
 
     @property

--- a/admin_panel/settings/models.py
+++ b/admin_panel/settings/models.py
@@ -237,10 +237,10 @@ class Settings(models.Model):
             return message.format(
                 user=mention,
                 ball=model.country,
-                emoji=bot.get_emoji(model.emoji_id),
+                emoji=str(bot.get_emoji(model.emoji_id)),
                 collectible=self.collectible_name,
                 collectibles=self.plural_collectible_name,
-                **kwargs,
+                **{k: str(v) for k, v in kwargs.items()},
             )
         except (ValueError, IndexError, KeyError):
             return message

--- a/ballsdex/packages/countryballs/countryball.py
+++ b/ballsdex/packages/countryballs/countryball.py
@@ -46,12 +46,11 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
 
         player, _ = await Player.objects.aget_or_create(discord_id=interaction.user.id)
         if self.view.caught:
-            slow_message = settings.get_random_message(PromptMessage.PromptType.SLOW).format(
-                user=interaction.user.mention,
-                collectible=settings.collectible_name,
-                ball=self.view.name,
-                collectibles=settings.plural_collectible_name,
-                emoji=interaction.client.get_emoji(self.view.model.emoji_id),
+            slow_message = settings.get_formatted_message(
+                category=PromptMessage.PromptType.SLOW,
+                mention=interaction.user.mention,
+                model=self.view.model,
+                bot=interaction.client,
             )
 
             await interaction.followup.send(slow_message, ephemeral=True, allowed_mentions=await can_mention([player]))
@@ -63,13 +62,12 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
             else:
                 wrong_name = self.name.value
 
-            wrong_message = settings.get_random_message(PromptMessage.PromptType.WRONG).format(
-                user=interaction.user.mention,
-                collectible=settings.collectible_name,
-                ball=self.view.name,
-                collectibles=settings.plural_collectible_name,
+            wrong_message = settings.get_formatted_message(
+                category=PromptMessage.PromptType.WRONG,
+                mention=interaction.user.mention,
+                model=self.view.model,
+                bot=interaction.client,
                 wrong=wrong_name,
-                emoji=interaction.client.get_emoji(self.view.model.emoji_id),
             )
             await interaction.followup.send(
                 wrong_message, allowed_mentions=await can_mention([player]), ephemeral=False
@@ -146,12 +144,11 @@ class BallSpawnView(View):
     @button(style=discord.ButtonStyle.primary, label="Catch me!")
     async def catch_button(self, interaction: discord.Interaction["BallsDexBot"], button: Button):
         if self.caught:
-            slow_message = settings.get_random_message(PromptMessage.PromptType.SLOW).format(
-                user=interaction.user.mention,
-                collectible=settings.collectible_name,
-                ball=self.name,
-                collectibles=settings.plural_collectible_name,
-                emoji=interaction.client.get_emoji(self.model.emoji_id),
+            slow_message = settings.get_formatted_message(
+                category=PromptMessage.PromptType.SLOW,
+                mention=interaction.user.mention,
+                model=self.model,
+                bot=interaction.client,
             )
             await interaction.response.send_message(slow_message, ephemeral=True)
         else:
@@ -244,11 +241,8 @@ class BallSpawnView(View):
         try:
             permissions = channel.permissions_for(channel.guild.me)
             if permissions.attach_files and permissions.send_messages:
-                spawn_message = settings.get_random_message(PromptMessage.PromptType.SPAWN).format(
-                    collectible=settings.collectible_name,
-                    ball=self.name,
-                    collectibles=settings.plural_collectible_name,
-                    emoji=self.bot.get_emoji(self.model.emoji_id),
+                spawn_message = settings.get_formatted_message(
+                    category=PromptMessage.PromptType.SPAWN, mention="", model=self.model, bot=self.bot
                 )
 
                 self.message = await channel.send(
@@ -409,12 +403,8 @@ class BallSpawnView(View):
             text += f"This {settings.collectible_name} was dropped by <@{self.og_id}>\n"
 
         caught_message = (
-            settings.get_random_message(PromptMessage.PromptType.CATCH).format(
-                user=mention,
-                collectible=settings.collectible_name,
-                ball=self.name,
-                collectibles=settings.plural_collectible_name,
-                emoji=self.bot.get_emoji(self.model.emoji_id),
+            settings.get_formatted_message(
+                category=PromptMessage.PromptType.CATCH, mention=mention, model=self.model, bot=self.bot
             )
             + " "
         )


### PR DESCRIPTION
### Description of the changes
Unifies prompt message handling and makes it fail gracefully when an invalid format string is passed in settings. I have some eventual plans to use the prompt message system in more places, eg in the catch button label, and this is a prerequisite for that. Even if those changes never happen, I think this is still cleaner than the 5x code duplication we had before (adding new format options was very messy before).

EDIT: oh, also makes the stringification for a prompt message not an empty string
<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.
To answer, add an "x" in between the square brackets [x] for the option you want to choose. 

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
- [x] Yes
- [ ] No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
