### PR TITLE
Fixed the crash that would happen when using /trade history days:number

### DIFF
--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -277,7 +277,7 @@ class Trade(commands.GroupCog):
 
         if days is not None and days > 0:
             start_date = timezone.now() - timedelta(days=days)
-            queryset = queryset.filter(date__ge=start_date)
+            queryset = queryset.filter(date__gte=start_date)
 
         if countryball and special:
             queryset = queryset.filter(


### PR DESCRIPTION
### Description of the changes
Currently the /trade history command crashes when using the days parameter, this PR fixes that
### Were the changes in this PR tested?

- [x] Yes
- [ ] No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
