### PR TITLE
refactor: update interaction responses to be deferal if theres db actions

### DIFF
--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -487,9 +487,11 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         if not countryball:
             return
 
+        await interaction.response.defer(thinking=True, ephemeral=True)
+
         if settings.max_favorites == 0:
-            await interaction.response.send_message(
-                f"You cannot set favorite {settings.plural_collectible_name} in this bot."
+            await interaction.followup.send(
+                f"You cannot set favorite {settings.plural_collectible_name} in this bot.", ephemeral=True
             )
             return
 
@@ -497,7 +499,7 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
             try:
                 player = await Player.objects.aget(discord_id=interaction.user.id)
             except Player.DoesNotExist:
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     f"You don't have any {settings.plural_collectible_name} yet.", ephemeral=True
                 )
                 return
@@ -506,7 +508,7 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
                 f"{settings.collectible_name}" if settings.max_favorites == 1 else f"{settings.plural_collectible_name}"
             )
             if await player.balls.filter(favorite=True).acount() >= settings.max_favorites:
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     f"You cannot set more than {settings.max_favorites} favorite {grammar}.", ephemeral=True
                 )
                 return
@@ -514,7 +516,7 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
             countryball.favorite = True  # type: ignore
             await countryball.asave()
             emoji = self.bot.get_emoji(countryball.countryball.emoji_id) or ""
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 f"{emoji} `#{countryball.pk:0X}` {countryball.countryball.country} "
                 f"is now a favorite {settings.collectible_name}!",
                 ephemeral=True,
@@ -524,7 +526,7 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
             countryball.favorite = False  # type: ignore
             await countryball.asave()
             emoji = self.bot.get_emoji(countryball.countryball.emoji_id) or ""
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 f"{emoji} `#{countryball.pk:0X}` {countryball.countryball.country} "
                 f"isn't a favorite {settings.collectible_name} anymore.",
                 ephemeral=True,

--- a/ballsdex/packages/countryballs/countryball.py
+++ b/ballsdex/packages/countryballs/countryball.py
@@ -80,7 +80,11 @@ class CountryballNamePrompt(Modal, title=f"Catch this {settings.collectible_name
             self.view.get_catch_message(ball, has_caught_before, interaction.user.mention),
             allowed_mentions=discord.AllowedMentions(users=player.can_be_mentioned),
         )
-        await interaction.followup.edit_message(self.view.message.id, view=self.view)
+        try:
+            await interaction.followup.edit_message(self.view.message.id, view=self.view)
+        except discord.NotFound:
+            # the spawn message was deleted before the catch completed; nothing to update
+            pass
 
 
 class BallSpawnView(View):
@@ -254,7 +258,7 @@ class BallSpawnView(View):
         except discord.Forbidden:
             log.warning(f"Missing permission to spawn ball in channel {channel}.")
         except discord.HTTPException:
-            log.error("Failed to spawn ball", exc_info=True)
+            log.error(f"Failed to spawn {self.name} in channel {channel}.", exc_info=True)
         return False
 
     def is_name_valid(self, text: str) -> bool:

--- a/ballsdex/packages/guildconfig/cog.py
+++ b/ballsdex/packages/guildconfig/cog.py
@@ -50,15 +50,14 @@ class Config(commands.GroupCog):
         channel: discord.TextChannel
             The channel you want to set, current one if not specified.
         """
+        await interaction.response.defer(thinking=True, ephemeral=True)
         user = cast(discord.Member, interaction.user)
 
         if channel is None:
             if isinstance(interaction.channel, discord.TextChannel):
                 channel = interaction.channel
             else:
-                await interaction.response.send_message(
-                    "The current channel is not a valid text channel.", ephemeral=True
-                )
+                await interaction.followup.send("The current channel is not a valid text channel.", ephemeral=True)
                 return
 
         view = AcceptTOSView(interaction, channel, user)
@@ -67,7 +66,7 @@ class Config(commands.GroupCog):
         guild = interaction.guild
         assert guild
         if guild.unavailable:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "The server is unavailable to the bot and will not work properly. "
                 "Kicking and readding the bot may fix this.",
                 ephemeral=True,
@@ -85,9 +84,7 @@ class Config(commands.GroupCog):
         message = await channel.send(embed=embed, view=view)
         view.message = message
 
-        await interaction.response.send_message(
-            f"The activation embed has been sent in {channel.mention}.", ephemeral=True
-        )
+        await interaction.followup.send(f"The activation embed has been sent in {channel.mention}.", ephemeral=True)
 
     @app_commands.command()
     @app_commands.checks.has_permissions(manage_guild=True)
@@ -96,13 +93,14 @@ class Config(commands.GroupCog):
         """
         Disable or enable countryballs spawning.
         """
+        await interaction.response.defer(thinking=True)
         guild = cast(discord.Guild, interaction.guild)  # guild-only command
         config, created = await GuildConfig.objects.aget_or_create(guild_id=interaction.guild_id)
         if config.enabled:
             config.enabled = False  # type: ignore
             await config.asave()
             self.bot.dispatch("ballsdex_settings_change", guild, enabled=False)
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 f"{settings.bot_name} is now disabled in this server. Commands will still be "
                 f"available, but the spawn of new {settings.plural_collectible_name} "
                 "is suspended.\nTo re-enable the spawn, use the same command."
@@ -113,18 +111,18 @@ class Config(commands.GroupCog):
             self.bot.dispatch("ballsdex_settings_change", guild, enabled=True)
             if config.spawn_channel and (channel := guild.get_channel(config.spawn_channel)):
                 if channel:
-                    await interaction.response.send_message(
+                    await interaction.followup.send(
                         f"{settings.bot_name} is now enabled in this server, "
                         f"{settings.plural_collectible_name} will start spawning "
                         f"soon in {channel.mention}."
                     )
                 else:
-                    await interaction.response.send_message(
+                    await interaction.followup.send(
                         "The spawning channel specified in the configuration is not available.", ephemeral=True
                     )
             else:
                 config_cmd = self.channel.extras.get("mention", "`/config channel`")
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     f"{settings.bot_name} is now enabled in this server, however there is no "
                     f"spawning channel set. Please configure one with {config_cmd}."
                 )
@@ -135,30 +133,29 @@ class Config(commands.GroupCog):
         """
         Check the server configuration status.
         """
+        await interaction.response.defer(thinking=True)
         config = await GuildConfig.objects.aget_or_none(guild_id=interaction.guild_id)
         config_cmd = self.channel.extras.get("mention", "`/config channel`")
         if not config or not config.spawn_channel:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 f"{settings.bot_name} is not configured in this server yet.\nPlease use {config_cmd} to set a channel.",
                 ephemeral=False,
             )
         else:
             assert interaction.guild
             if interaction.guild.unavailable:
-                await interaction.response.send_message(
-                    "Your server is unavailable to the bot. Readding it may fix this."
-                )
+                await interaction.followup.send("Your server is unavailable to the bot. Readding it may fix this.")
                 return
             channel = interaction.guild.get_channel(config.spawn_channel)
             if channel:
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     f"{settings.bot_name} is configured in this server.\n"
                     f"Spawn channel: {channel.mention}\n"
                     f"Status: {'Enabled' if config.enabled else 'Disabled'}",
                     ephemeral=False,
                 )
             else:
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     f"{settings.bot_name} is configured, but the specified channel "
                     "could not be found.\n"
                     f"Please use {config_cmd} to set it again.",

--- a/ballsdex/packages/info/cog.py
+++ b/ballsdex/packages/info/cog.py
@@ -60,6 +60,7 @@ class Info(commands.Cog):
         """
         Get information about this bot.
         """
+        await interaction.response.defer(thinking=True)
         embed = discord.Embed(title=f"{settings.bot_name} Discord bot", color=discord.Colour.blurple())
 
         try:
@@ -143,13 +144,14 @@ class Info(commands.Cog):
         view = LicenseInfo()
         if not extra_apps_dist:
             view.remove_item(view.children[-1])
-        await interaction.response.send_message(embed=embed, view=view)
+        await interaction.followup.send(embed=embed, view=view)
 
     @app_commands.command()
     async def help(self, interaction: discord.Interaction["BallsDexBot"]):
         """
         Show the list of commands from the bot.
         """
+        await interaction.response.defer(thinking=True)
         assert self.bot.user
         embed = discord.Embed(title=f"{settings.bot_name} Discord bot - help menu", color=discord.Colour.blurple())
         embed.set_thumbnail(url=self.bot.user.display_avatar.url)
@@ -171,4 +173,4 @@ class Info(commands.Cog):
             for i, page in enumerate(pages):
                 embed.add_field(name=cog.qualified_name if i == 0 else "\u200b", value=page, inline=False)
 
-        await interaction.response.send_message(embed=embed)
+        await interaction.followup.send(embed=embed)

--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -62,7 +62,7 @@ class Player(commands.GroupCog):
         user: discord.User
             The user you want to add as a friend.
         """
-        await interaction.response.defer(thinking=True)
+        await interaction.response.defer(thinking=True, ephemeral=True)
         player1, _ = await PlayerModel.objects.aget_or_create(discord_id=interaction.user.id)
         player2, _ = await PlayerModel.objects.aget_or_create(discord_id=user.id)
 

--- a/ballsdex/packages/players/cog.py
+++ b/ballsdex/packages/players/cog.py
@@ -44,12 +44,13 @@ class Player(commands.GroupCog):
         """
         Edit your player settings
         """
+        await interaction.response.defer(thinking=True, ephemeral=True)
         player, _ = await PlayerModel.objects.aget_or_create(discord_id=interaction.user.id)
         layout = LayoutView()
         container = SettingsContainer()
         container.configure(interaction, player)
         layout.add_item(container)
-        await interaction.response.send_message(view=layout, ephemeral=True)
+        await interaction.followup.send(view=layout, ephemeral=True)
 
     @friend.command(name="add")
     async def friend_add(self, interaction: discord.Interaction["BallsDexBot"], user: discord.User):
@@ -61,20 +62,21 @@ class Player(commands.GroupCog):
         user: discord.User
             The user you want to add as a friend.
         """
+        await interaction.response.defer(thinking=True)
         player1, _ = await PlayerModel.objects.aget_or_create(discord_id=interaction.user.id)
         player2, _ = await PlayerModel.objects.aget_or_create(discord_id=user.id)
 
         if player1 == player2:
-            await interaction.response.send_message("You cannot add yourself as a friend.", ephemeral=True)
+            await interaction.followup.send("You cannot add yourself as a friend.", ephemeral=True)
             return
         if user.bot:
-            await interaction.response.send_message("You cannot add a bot.", ephemeral=True)
+            await interaction.followup.send("You cannot add a bot.", ephemeral=True)
             return
         if player2.discord_id in self.bot.blacklist:
-            await interaction.response.send_message("You cannot add a blacklisted user as a friend.", ephemeral=True)
+            await interaction.followup.send("You cannot add a blacklisted user as a friend.", ephemeral=True)
             return
         if player2.friend_policy == FriendPolicy.DENY:
-            await interaction.response.send_message("This user isn't accepting friend requests.", ephemeral=True)
+            await interaction.followup.send("This user isn't accepting friend requests.", ephemeral=True)
             return
 
         blocked = await player1.is_blocked(player2)
@@ -82,23 +84,23 @@ class Player(commands.GroupCog):
 
         if blocked:
             player_unblock = self.block_remove.extras.get("mention", "/player block remove")
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 f"You cannot add a blocked user. To unblock, use {player_unblock}.", ephemeral=True
             )
             return
         if player2_blocked:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "This user has blocked you, you cannot add them as a friend.", ephemeral=True
             )
             return
 
         friended = await player1.is_friend(player2)
         if friended:
-            await interaction.response.send_message("You are already friends with this user!", ephemeral=True)
+            await interaction.followup.send("You are already friends with this user!", ephemeral=True)
             return
 
         if self.active_friend_requests.get((player2.discord_id, player1.discord_id), False):
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "That user has already sent you a friend request! "
                 "Please accept or decline it before sending a new request.",
                 ephemeral=True,
@@ -106,12 +108,9 @@ class Player(commands.GroupCog):
             return
 
         if self.active_friend_requests.get((player1.discord_id, player2.discord_id), False):
-            await interaction.response.send_message(
-                "You already have an active friend request to this user!", ephemeral=True
-            )
+            await interaction.followup.send("You already have an active friend request to this user!", ephemeral=True)
             return
 
-        await interaction.response.defer(thinking=True)
         view = ConfirmChoiceView(
             interaction, user=user, accept_message="Friend request accepted!", cancel_message="Friend request declined."
         )
@@ -140,31 +139,33 @@ class Player(commands.GroupCog):
         user: discord.User
             The user you want to remove as a friend.
         """
+        await interaction.response.defer(thinking=True, ephemeral=True)
         player1, _ = await PlayerModel.objects.aget_or_create(discord_id=interaction.user.id)
         player2, _ = await PlayerModel.objects.aget_or_create(discord_id=user.id)
 
         if player1 == player2:
-            await interaction.response.send_message("You cannot remove yourself.", ephemeral=True)
+            await interaction.followup.send("You cannot remove yourself.", ephemeral=True)
             return
         if user.bot:
-            await interaction.response.send_message("You cannot remove a bot.", ephemeral=True)
+            await interaction.followup.send("You cannot remove a bot.", ephemeral=True)
             return
 
         friendship_exists = await player1.is_friend(player2)
         if not friendship_exists:
-            await interaction.response.send_message("You are not friends with this user.", ephemeral=True)
+            await interaction.followup.send("You are not friends with this user.", ephemeral=True)
             return
         else:
             await Friendship.objects.filter(
                 (Q(player1=player1) & Q(player2=player2)) | (Q(player1=player2) & Q(player2=player1))
             ).adelete()
-            await interaction.response.send_message(f"{user.name} has been removed as a friend.", ephemeral=True)
+            await interaction.followup.send(f"{user.name} has been removed as a friend.", ephemeral=True)
 
     @friend.command(name="list")
     async def friend_list(self, interaction: discord.Interaction["BallsDexBot"]):
         """
         View all your friends.
         """
+        await interaction.response.defer(thinking=True, ephemeral=True)
         player, _ = await PlayerModel.objects.aget_or_create(discord_id=interaction.user.id)
         qs = (
             Friendship.objects.filter(Q(player1=player) | Q(player2=player))
@@ -173,7 +174,7 @@ class Player(commands.GroupCog):
         )
 
         if not await qs.aexists():
-            await interaction.response.send_message("You currently do not have any friends added.", ephemeral=True)
+            await interaction.followup.send("You currently do not have any friends added.", ephemeral=True)
             return
 
         view = LayoutView()
@@ -189,7 +190,7 @@ class Player(commands.GroupCog):
             ItemFormatter(container, 1),
         )
         await menu.init()
-        await interaction.response.send_message(view=view, ephemeral=True)
+        await interaction.followup.send(view=view, ephemeral=True)
 
     @blocked.command(name="add")
     async def block_add(self, interaction: discord.Interaction["BallsDexBot"], user: discord.User):
@@ -201,10 +202,10 @@ class Player(commands.GroupCog):
         user: discord.User
             The user you want to block.
         """
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
         player1, _ = await PlayerModel.objects.aget_or_create(discord_id=interaction.user.id)
         player2, _ = await PlayerModel.objects.aget_or_create(discord_id=user.id)
-
-        await interaction.response.defer(ephemeral=True, thinking=True)
 
         if player1 == player2:
             await interaction.followup.send("You cannot block yourself.", ephemeral=True)
@@ -255,35 +256,37 @@ class Player(commands.GroupCog):
         user: discord.User
             The user you want to unblock.
         """
+        await interaction.response.defer(thinking=True, ephemeral=True)
         player1, _ = await PlayerModel.objects.aget_or_create(discord_id=interaction.user.id)
         player2, _ = await PlayerModel.objects.aget_or_create(discord_id=user.id)
 
         if player1 == player2:
-            await interaction.response.send_message("You cannot unblock yourself.", ephemeral=True)
+            await interaction.followup.send("You cannot unblock yourself.", ephemeral=True)
             return
         if user.bot:
-            await interaction.response.send_message("You cannot unblock a bot.", ephemeral=True)
+            await interaction.followup.send("You cannot unblock a bot.", ephemeral=True)
             return
 
         blocked = await player1.is_blocked(player2)
 
         if not blocked:
-            await interaction.response.send_message("This user isn't blocked.", ephemeral=True)
+            await interaction.followup.send("This user isn't blocked.", ephemeral=True)
             return
         else:
             await Block.objects.filter((Q(player1=player1) & Q(player2=player2))).adelete()
-            await interaction.response.send_message(f"{user.name} has been unblocked.", ephemeral=True)
+            await interaction.followup.send(f"{user.name} has been unblocked.", ephemeral=True)
 
     @blocked.command(name="list")
     async def blocked_list(self, interaction: discord.Interaction["BallsDexBot"]):
         """
         View all the users you have blocked.
         """
+        await interaction.response.defer(thinking=True, ephemeral=True)
         player, _ = await PlayerModel.objects.aget_or_create(discord_id=interaction.user.id)
         qs = Block.objects.filter(player1=player).select_related("player1", "player2").order_by("date")
 
         if not await qs.aexists():
-            await interaction.response.send_message("You haven't blocked any users!", ephemeral=True)
+            await interaction.followup.send("You haven't blocked any users!", ephemeral=True)
             return
 
         view = LayoutView()
@@ -299,7 +302,7 @@ class Player(commands.GroupCog):
             ItemFormatter(container, 1),
         )
         await menu.init()
-        await interaction.response.send_message(view=view, ephemeral=True)
+        await interaction.followup.send(view=view, ephemeral=True)
 
     @app_commands.command()
     async def info(self, interaction: discord.Interaction["BallsDexBot"]):

--- a/ballsdex/packages/trade/cog.py
+++ b/ballsdex/packages/trade/cog.py
@@ -99,42 +99,42 @@ class Trade(commands.GroupCog):
             The user you want to trade with.
         """
         assert interaction.channel
+        await interaction.response.defer(ephemeral=True)
         if self.lockdown is not None:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 f"Trading has been globally disabled by the admins for the following reason: {self.lockdown}",
                 ephemeral=True,
             )
             return
 
         if user.bot:
-            await interaction.response.send_message("You cannot trade with bots.", ephemeral=True)
+            await interaction.followup.send("You cannot trade with bots.", ephemeral=True)
             return
         if user.id == interaction.user.id:
-            await interaction.response.send_message("You cannot trade with yourself.", ephemeral=True)
+            await interaction.followup.send("You cannot trade with yourself.", ephemeral=True)
             return
 
         player1, _ = await Player.objects.aget_or_create(discord_id=interaction.user.id)
         player2, _ = await Player.objects.aget_or_create(discord_id=user.id)
         blocked = await player1.is_blocked(player2)
         if blocked:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "You cannot begin a trade with a user that you have blocked.", ephemeral=True
             )
             return
         blocked2 = await player2.is_blocked(player1)
         if blocked2:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "You cannot begin a trade with a user that has blocked you.", ephemeral=True
             )
             return
         if await self.get_trade(interaction) is not None:
-            await interaction.response.send_message("You already have an active trade.", ephemeral=True)
+            await interaction.followup.send("You already have an active trade.", ephemeral=True)
             return
         if await self.get_trade(interaction, user) is not None:
-            await interaction.response.send_message(f"{user.mention} already has an active trade.", ephemeral=True)
+            await interaction.followup.send(f"{user.mention} already has an active trade.", ephemeral=True)
             return
 
-        await interaction.response.defer(ephemeral=True)
         trade = TradeInstance.configure(self, (player1, interaction.user), (player2, user))
         # APM: tag the command span with the trade id and capture its trace context so
         # every subsequent button/modal interaction on this trade links back here.
@@ -174,18 +174,19 @@ class Trade(commands.GroupCog):
         special: Special | None
             The special you want to filter the countryball by.
         """
+        await interaction.response.defer(thinking=True, ephemeral=True)
         result = await self.get_trade(interaction)
         if result is None:
-            await interaction.response.send_message("You do not have any active trade.", ephemeral=True)
+            await interaction.followup.send("You do not have any active trade.", ephemeral=True)
             return
         trade, trader = result
         try:
             await trader.add_to_proposal(BallInstance.objects.filter(id=countryball.pk))
         except TradeError as e:
-            await interaction.response.send_message(e.error_message, ephemeral=True)
+            await interaction.followup.send(e.error_message, ephemeral=True)
         else:
             await trade.edit_message(None)
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 f"{countryball.description(is_trade=True, include_emoji=True, bot=self.bot)} added.", ephemeral=True
             )
 
@@ -206,18 +207,19 @@ class Trade(commands.GroupCog):
         special: Special | None
             The special you want to filter the countryball by.
         """
+        await interaction.response.defer(thinking=True, ephemeral=True)
         result = await self.get_trade(interaction)
         if result is None:
-            await interaction.response.send_message("You do not have any active trade.", ephemeral=True)
+            await interaction.followup.send("You do not have any active trade.", ephemeral=True)
             return
         trade, trader = result
         try:
             await trader.remove_from_proposal(BallInstance.objects.filter(id=countryball.pk))
         except TradeError as e:
-            await interaction.response.send_message(e.error_message, ephemeral=True)
+            await interaction.followup.send(e.error_message, ephemeral=True)
         else:
             await trade.edit_message(None)
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 f"{countryball.description(is_trade=True, include_emoji=True, bot=self.bot)} removed.", ephemeral=True
             )
 
@@ -268,7 +270,7 @@ class Trade(commands.GroupCog):
             if trade_user:
                 p2 = await Player.objects.only("id").aget(discord_id=trade_user.id)
         except Player.DoesNotExist:
-            await interaction.response.send_message("One of the players does not exist.", ephemeral=True)
+            await interaction.followup.send("One of the players does not exist.", ephemeral=True)
             return
         if trade_user:
             queryset = queryset.filter((Q(player1=p1, player2=p2)) | (Q(player1=p2, player2=p1)))


### PR DESCRIPTION
Replaced all commands that have db actions to use deferal, so they wont just drop/int failed if theres any hanging with the db

* Replaced all uses of `interaction.response.send_message` with `interaction.followup.send` after deferring responses, ensuring proper handling of ephemeral and long-running interactions across commands in `balls/cog.py`, `guildconfig/cog.py`, `info/cog.py`, and `players/cog.py`. [

* Added `await interaction.response.defer(...)` at the start of all relevant command handlers to indicate processing and prevent timeouts for longer operations. This was consistently applied to commands that modify state or might take time, such as favourites, settings, friend/block management, and configuration. 

**Error Handling and Logging Improvements:**

* Improved error handling in `countryballs/countryball.py` by adding a try/except block to gracefully handle cases where a message to be edited was deleted before completion, preventing uncaught exceptions.

* Enhanced logging for failed ball spawns to include the ball name and channel, making debugging easier.

