### PR TITLE
Fix admin syncslash

### DIFF
--- a/ballsdex/packages/admin/cog.py
+++ b/ballsdex/packages/admin/cog.py
@@ -163,7 +163,7 @@ class Admin(commands.Cog):
             if not view.value:
                 return
             async with ctx.typing():
-                self.bot.tree.add_command(self.admin.app_command, guild=ctx.guild)
+                self.bot.tree.add_command(self.admin.app_command, guild=ctx.guild, override=True)
                 await self.bot.tree.sync(guild=ctx.guild)
                 log.info(f"Admin commands added to guild {ctx.guild.id} by {ctx.author}")
                 await ctx.send(


### PR DESCRIPTION
### Description of the changes

This fixes an intermittent bug where admin syncslash fails because "command "admin" is already registered" when it is not.

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.
To answer, add an "x" in between the square brackets [x] for the option you want to choose. 

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Not locally, since I was unable to reproduce the bug myself, but it worked on a patreon dex.

