### PR TITLE
Polish /balls last, duplicate, and compare

### DIFF
--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -400,6 +400,7 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         interaction: discord.Interaction["BallsDexBot"],
         user: discord.User | None = None,
         filter: FilteringChoices | None = None,
+        index: app_commands.Range[int, 1] = 1,
     ):
         """
         Display info of your or another users last caught countryball.
@@ -411,6 +412,8 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         filter: FilteringChoices
             Filter the last caught countryball by a specific filter.
             Only works if the user has caught at least one countryball.
+        index: int
+            How far back to look. 1 is the most recent catch, 2 the one before that, and so on.
         """
         user_obj = user if user else interaction.user
         await interaction.response.defer(thinking=True)
@@ -449,21 +452,32 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         if filter:
             filter_msg = f" with the `{filter.value.replace('_', ' ')}` filter"
             query = filter_balls(filter, query, interaction.guild_id)
-        countryball = await query.order_by("-id").afirst()
+        matches = [cb async for cb in query.order_by("-id")[index - 1 : index]]
+        countryball = matches[0] if matches else None
         if not countryball:
-            msg = f"{'You do' if user is None else f'{user_obj.display_name} does'}"
-            await interaction.followup.send(
-                f"{msg} not have any {settings.plural_collectible_name} yet.", ephemeral=True
-            )
+            if index == 1:
+                msg = f"{'You do' if user is None else f'{user_obj.display_name} does'}"
+                await interaction.followup.send(
+                    f"{msg} not have any {settings.plural_collectible_name} yet.", ephemeral=True
+                )
+            else:
+                who = "You don't" if user is None else f"{user_obj.display_name} doesn't"
+                await interaction.followup.send(
+                    f"{who} have {index} caught {settings.plural_collectible_name}{filter_msg} yet.", ephemeral=True
+                )
             return
 
+        index_msg = "" if index == 1 else f" ({index} catches back)"
         content, file, view = await countryball.prepare_for_message(interaction)
         if user is not None and user.id != interaction.user.id:
             content = (
-                f"You are viewing {user.display_name}'s last caught {settings.collectible_name}{filter_msg}.\n{content}"
+                f"You are viewing {user.display_name}'s last caught "
+                f"{settings.collectible_name}{filter_msg}{index_msg}.\n{content}"
             )
         else:
-            content = f"You are viewing your last caught {settings.collectible_name}{filter_msg}.\n" + content
+            content = (
+                f"You are viewing your last caught {settings.collectible_name}{filter_msg}{index_msg}.\n" + content
+            )
         await interaction.followup.send(content=content, file=file, view=view)
         file.close()
 
@@ -701,7 +715,11 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
     @app_commands.command()
     @app_commands.checks.cooldown(1, 20, key=lambda i: i.user.id)
     async def duplicate(
-        self, interaction: discord.Interaction["BallsDexBot"], type: DuplicateType, limit: int | None = None
+        self,
+        interaction: discord.Interaction["BallsDexBot"],
+        type: DuplicateType,
+        limit: app_commands.Range[int, 1] | None = None,
+        reverse: bool = False,
     ):
         """
         Shows your most duplicated countryballs or specials.
@@ -711,7 +729,9 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         type: DuplicateType
             Type of duplicate to check (countryballs or specials).
         limit: int | None
-            The amount of countryballs to show, can only be used with `countryballs`.
+            The amount of countryballs to show (default: all), can only be used with `countryballs`.
+        reverse: bool
+            Show your least duplicated countryballs or specials first instead.
         """
         await interaction.response.defer(thinking=True, ephemeral=True)
 
@@ -731,7 +751,7 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         query = (
             queryset.values(annotations["value_id"].name)
             .annotate(**annotations, count=Count("value_id"))
-            .order_by("-count")
+            .order_by("count" if reverse else "-count")
         )
 
         if apply_limit and limit is not None:
@@ -755,7 +775,8 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
 
         view = CountryballsDuplicateSource(is_special)
         view.restrict_author(interaction.user.id)
-        view.header.content = f"View your duplicate {type.value}."
+        order_msg = " (least duplicated first)" if reverse else ""
+        view.header.content = f"View your duplicate {type.value}{order_msg}."
         menu = Menu(self.bot, view, ChunkedListSource(entries), SelectFormatter(view.callback))
         await menu.init(position=2)
         message = await interaction.followup.send(view=view, wait=True)
@@ -769,6 +790,8 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         user: discord.User,
         special: SpecialEnabledTransform | None = None,
         duplicates: bool = False,
+        filter: FilteringChoices | None = None,
+        diff_only: bool = False,
     ):
         """
         Compare your countryballs with another user.
@@ -781,6 +804,11 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
             Filter the results of the comparison to a special event.
         duplicates: bool
             Whether to compare duplicates.
+        filter: FilteringChoices
+            Filter the compared countryballs by a specific filter.
+        diff_only: bool
+            Only show what's different between you and the other user, hiding "Both have" and
+            "Neither have" - useful for large collections.
         """
         await interaction.response.defer(thinking=True)
         if interaction.user == user:
@@ -824,10 +852,12 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
             await interaction.followup.send("You cannot compare with a user that has you blocked.", ephemeral=True)
             return
         queryset = BallInstance.objects.filter(ball__enabled=True).distinct()
-        if duplicates:
-            queryset = queryset.values("ball_id").annotate(counts=Count("ball_id")).filter(counts__gt=1)
         if special:
             queryset = queryset.filter(special=special)
+        if filter:
+            queryset = filter_balls(filter, queryset, interaction.guild_id)
+        if duplicates:
+            queryset = queryset.values("ball_id").annotate(counts=Count("ball_id")).filter(counts__gt=1)
         user1_balls = cast(
             list[int], [x async for x in queryset.filter(player=player1).values_list("ball_id", flat=True)]
         )
@@ -849,7 +879,8 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
                 text += "None\n"
                 return
 
-            for ball_id in ids:
+            # deterministic, readable ordering instead of arbitrary set iteration order
+            for ball_id in sorted(ids, key=lambda i: balls[i].country if i in balls else ""):
                 emoji = self.bot.get_emoji(bot_countryballs[ball_id])
                 if not emoji:
                     continue
@@ -858,10 +889,12 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
 
         all_ball_ids = set(bot_countryballs.keys())
         u1_s, u2_s = set(user1_balls), set(user2_balls)
-        fill_fields("Both have", u1_s & u2_s)
+        if not diff_only:
+            fill_fields("Both have", u1_s & u2_s)
         fill_fields(f"Only {interaction.user.display_name} has", u1_s - u2_s)
         fill_fields(f"Only {user.display_name} has", u2_s - u1_s)
-        fill_fields("Neither have", all_ball_ids - u1_s - u2_s)
+        if not diff_only:
+            fill_fields("Neither have", all_ball_ids - u1_s - u2_s)
 
         view = LayoutView()
         container = Container()


### PR DESCRIPTION
## Summary
- `/balls last`: add an `index` param (1 = most recent, 2 = one before that, etc.) instead of always showing only the single most recent catch.
- `/balls duplicate`: add `reverse` to show least-duplicated first; clarified the `limit` docstring to note it defaults to showing everything.
- `/balls compare`: add `filter:` (matching the other list-style commands), a `diff_only` toggle that hides the "Both have"/"Neither have" sections for large collections, and switched the per-group emoji listing to a deterministic alphabetical order instead of relying on Python `set` iteration order (which is unordered and could vary between runs).

## Test plan
- [ ] `/balls last index:2` shows the second-most-recent catch; `index:1` (default) unchanged
- [ ] `/balls last index:99` (out of range) gives a sensible "you don't have that many" message
- [ ] `/balls duplicate type:countryballs reverse:True` shows least-duplicated first
- [ ] `/balls compare @user filter:favorites` and `diff_only:True` behave as expected
- [ ] `ruff check .` and `pyright` pass