### PR TITLE
Polish /config channel, disable, and status

### DIFF
--- a/ballsdex/packages/guildconfig/cog.py
+++ b/ballsdex/packages/guildconfig/cog.py
@@ -61,9 +61,6 @@ class Config(commands.GroupCog):
                 )
                 return
 
-        view = AcceptTOSView(interaction, channel, user)
-        embed = activation_embed.copy()
-
         guild = interaction.guild
         assert guild
         if guild.unavailable:
@@ -73,6 +70,28 @@ class Config(commands.GroupCog):
                 ephemeral=True,
             )
             return
+
+        channel_perms = channel.permissions_for(guild.me)
+        missing_perms = [
+            name
+            for name, granted in (
+                ("Read Messages", channel_perms.read_messages),
+                ("Send Messages", channel_perms.send_messages),
+                ("Embed Links", channel_perms.embed_links),
+            )
+            if not granted
+        ]
+        if missing_perms:
+            await interaction.response.send_message(
+                f"{settings.bot_name} is missing the following permission(s) in {channel.mention}: "
+                f"**{', '.join(missing_perms)}**. Please grant them, then try again.",
+                ephemeral=True,
+            )
+            return
+
+        view = AcceptTOSView(interaction, channel, user)
+        embed = activation_embed.copy()
+
         readable_channels = len([x for x in guild.text_channels if x.permissions_for(guild.me).read_messages])
         if readable_channels / len(guild.text_channels) < 0.75:
             embed.add_field(
@@ -86,7 +105,10 @@ class Config(commands.GroupCog):
         view.message = message
 
         await interaction.response.send_message(
-            f"The activation embed has been sent in {channel.mention}.", ephemeral=True
+            f"The activation embed has been sent in {channel.mention}. Once accepted, "
+            f"{settings.plural_collectible_name} will start spawning there based on message activity - "
+            "send a few messages to trigger a test spawn.",
+            ephemeral=True,
         )
 
     @app_commands.command()
@@ -103,7 +125,7 @@ class Config(commands.GroupCog):
             await config.asave()
             self.bot.dispatch("ballsdex_settings_change", guild, enabled=False)
             await interaction.response.send_message(
-                f"{settings.bot_name} is now disabled in this server. Commands will still be "
+                f"Spawning is now **disabled** in this server. Commands will still be "
                 f"available, but the spawn of new {settings.plural_collectible_name} "
                 "is suspended.\nTo re-enable the spawn, use the same command."
             )
@@ -114,7 +136,7 @@ class Config(commands.GroupCog):
             if config.spawn_channel and (channel := guild.get_channel(config.spawn_channel)):
                 if channel:
                     await interaction.response.send_message(
-                        f"{settings.bot_name} is now enabled in this server, "
+                        f"Spawning is now **enabled** in this server, "
                         f"{settings.plural_collectible_name} will start spawning "
                         f"soon in {channel.mention}."
                     )
@@ -125,7 +147,7 @@ class Config(commands.GroupCog):
             else:
                 config_cmd = self.channel.extras.get("mention", "`/config channel`")
                 await interaction.response.send_message(
-                    f"{settings.bot_name} is now enabled in this server, however there is no "
+                    f"Spawning is now **enabled** in this server, however there is no "
                     f"spawning channel set. Please configure one with {config_cmd}."
                 )
 
@@ -137,30 +159,40 @@ class Config(commands.GroupCog):
         """
         config = await GuildConfig.objects.aget_or_none(guild_id=interaction.guild_id)
         config_cmd = self.channel.extras.get("mention", "`/config channel`")
+        embed = discord.Embed(title=f"{settings.bot_name} configuration status", color=discord.Colour.blurple())
+
         if not config or not config.spawn_channel:
-            await interaction.response.send_message(
-                f"{settings.bot_name} is not configured in this server yet.\nPlease use {config_cmd} to set a channel.",
-                ephemeral=False,
-            )
-        else:
-            assert interaction.guild
-            if interaction.guild.unavailable:
-                await interaction.response.send_message(
-                    "Your server is unavailable to the bot. Readding it may fix this."
-                )
-                return
-            channel = interaction.guild.get_channel(config.spawn_channel)
-            if channel:
-                await interaction.response.send_message(
-                    f"{settings.bot_name} is configured in this server.\n"
-                    f"Spawn channel: {channel.mention}\n"
-                    f"Status: {'Enabled' if config.enabled else 'Disabled'}",
-                    ephemeral=False,
-                )
-            else:
-                await interaction.response.send_message(
-                    f"{settings.bot_name} is configured, but the specified channel "
-                    "could not be found.\n"
-                    f"Please use {config_cmd} to set it again.",
-                    ephemeral=False,
-                )
+            embed.description = f"{settings.bot_name} is not configured in this server yet."
+            embed.add_field(name="Channel", value=f"Not set - use {config_cmd}", inline=False)
+            await interaction.response.send_message(embed=embed)
+            return
+
+        assert interaction.guild
+        if interaction.guild.unavailable:
+            await interaction.response.send_message("Your server is unavailable to the bot. Readding it may fix this.")
+            return
+
+        channel = interaction.guild.get_channel(config.spawn_channel)
+        if not channel:
+            embed.description = f"{settings.bot_name} is configured, but the specified channel could not be found."
+            embed.add_field(name="Channel", value=f"Not found - use {config_cmd} to set it again", inline=False)
+            await interaction.response.send_message(embed=embed)
+            return
+
+        embed.add_field(name="Channel", value=channel.mention, inline=True)
+        embed.add_field(name="Status", value="Enabled" if config.enabled else "Disabled", inline=True)
+
+        def tick(granted: bool) -> str:
+            return "\N{WHITE HEAVY CHECK MARK}" if granted else "\N{CROSS MARK}"
+
+        channel_perms = channel.permissions_for(interaction.guild.me)
+        checks = (
+            ("Read Messages", channel_perms.read_messages),
+            ("Send Messages", channel_perms.send_messages),
+            ("Embed Links", channel_perms.embed_links),
+            ("Attach Files", channel_perms.attach_files),
+        )
+        health_lines = "\n".join(f"{tick(granted)} {name}" for name, granted in checks)
+        embed.add_field(name="Permissions", value=health_lines, inline=False)
+
+        await interaction.response.send_message(embed=embed)


### PR DESCRIPTION
## Summary
- `/config channel`: validate the bot's channel-specific permissions (read/send/embed - overwrites can differ from guild-wide perms) before sending the activation embed, reporting exactly which are missing instead of erroring later. Success message now echoes the channel and adds a short "test spawn" hint.
- `/config disable`: bolded the enabled/disabled state in the response for clearer scanning ("Spawning is now **enabled**/**disabled**").
- `/config status`: replaced the plain-text responses with a single embed showing Channel, Status, and a permission health-check (checkmarks for Read/Send/Embed/Attach) for the configured spawn channel.

## Test plan
- [ ] `/config channel` in a channel where the bot is missing e.g. Embed Links reports that specifically, without attempting to send
- [ ] `/config channel` success path still sends the activation embed and echoes the channel
- [ ] `/config disable` toggling both directions shows clear bold enabled/disabled wording
- [ ] `/config status` (not configured / channel missing / fully configured) all render as embeds
- [ ] `ruff check .` and `pyright` pass