### PR TITLE
Confirm + echo resolved ball before admin balls delete/transfer

### DIFF
--- a/ballsdex/packages/admin/balls.py
+++ b/ballsdex/packages/admin/balls.py
@@ -373,11 +373,7 @@ async def balls_transferinv(
         await ctx.send(f"{source}'s inventory is empty.", ephemeral=True)
         return
 
-    view = ConfirmChoiceView(
-        ctx,
-        accept_message="Confirmed, transferring...",
-        cancel_message="Request cancelled.",
-    )
+    view = ConfirmChoiceView(ctx, accept_message="Confirmed, transferring...", cancel_message="Request cancelled.")
     if currency:
         text = (
             f"Are you sure you want to transfer {balls_count} {settings.plural_collectible_name} and "

--- a/ballsdex/packages/admin/balls.py
+++ b/ballsdex/packages/admin/balls.py
@@ -267,13 +267,15 @@ async def balls_delete(ctx: commands.Context[BallsDexBot], countryball_id: str, 
         await ctx.send(f"The {settings.collectible_name} ID you gave does not exist.", ephemeral=True)
         return
 
+    owner = await ctx.bot.fetch_user(ball.player.discord_id)
+
     method = "soft" if soft_delete else "hard"
     view = ConfirmChoiceView(
         ctx, accept_message=f"Confirmed, {method} deleting...", cancel_message="Request cancelled."
     )
     await ctx.send(
         f"You are about to {method} delete {ball.description(include_emoji=True, bot=ctx.bot)} "
-        f"(ID: `{countryball_id}`) owned by `{ball.player}`. Are you sure?",
+        f"(ID: `{countryball_id}`) owned by `{owner}`. Are you sure?",
         view=view,
         ephemeral=True,
     )
@@ -317,10 +319,12 @@ async def balls_transfer(ctx: commands.Context[BallsDexBot], countryball_id: str
         await ctx.send(f"The {settings.collectible_name} ID you gave does not exist.", ephemeral=True)
         return
 
+    original_owner = await ctx.bot.fetch_user(original_player.discord_id)
+
     view = ConfirmChoiceView(ctx, accept_message="Confirmed, transferring...", cancel_message="Request cancelled.")
     await ctx.send(
         f"You are about to transfer {ball.description(include_emoji=True, bot=ctx.bot)} "
-        f"(ID: `{countryball_id}`) from `{original_player}` to `{user}`. Are you sure?",
+        f"(ID: `{countryball_id}`) from `{original_owner}` to `{user}`. Are you sure?",
         view=view,
         ephemeral=True,
     )

--- a/ballsdex/packages/admin/balls.py
+++ b/ballsdex/packages/admin/balls.py
@@ -369,7 +369,11 @@ async def balls_transferinv(
         await ctx.send(f"{source}'s inventory is empty.", ephemeral=True)
         return
 
-    view = ConfirmChoiceView(ctx)
+    view = ConfirmChoiceView(
+        ctx,
+        accept_message="Confirmed, transferring...",
+        cancel_message="Request cancelled.",
+    )
     if currency:
         text = (
             f"Are you sure you want to transfer {balls_count} {settings.plural_collectible_name} and "

--- a/ballsdex/packages/admin/balls.py
+++ b/ballsdex/packages/admin/balls.py
@@ -260,10 +260,27 @@ async def balls_delete(ctx: commands.Context[BallsDexBot], countryball_id: str, 
         await ctx.send(f"The {settings.collectible_name} ID you gave is not valid.", ephemeral=True)
         return
     try:
-        ball = await BallInstance.objects.aget(id=ballIdConverted)
+        ball = await BallInstance.objects.prefetch_related("player").aget(id=ballIdConverted)
     except BallInstance.DoesNotExist:
         await ctx.send(f"The {settings.collectible_name} ID you gave does not exist.", ephemeral=True)
         return
+
+    method = "soft" if soft_delete else "hard"
+    view = ConfirmChoiceView(
+        ctx,
+        accept_message=f"Confirmed, {method} deleting...",
+        cancel_message="Request cancelled.",
+    )
+    await ctx.send(
+        f"You are about to {method} delete {ball.description(include_emoji=True, bot=ctx.bot)} "
+        f"(ID: `{countryball_id}`) owned by `{ball.player}`. Are you sure?",
+        view=view,
+        ephemeral=True,
+    )
+    await view.wait()
+    if not view.value:
+        return
+
     if soft_delete:
         ball.deleted = True
         await ball.asave()
@@ -299,6 +316,22 @@ async def balls_transfer(ctx: commands.Context[BallsDexBot], countryball_id: str
     except BallInstance.DoesNotExist:
         await ctx.send(f"The {settings.collectible_name} ID you gave does not exist.", ephemeral=True)
         return
+
+    view = ConfirmChoiceView(
+        ctx,
+        accept_message="Confirmed, transferring...",
+        cancel_message="Request cancelled.",
+    )
+    await ctx.send(
+        f"You are about to transfer {ball.description(include_emoji=True, bot=ctx.bot)} "
+        f"(ID: `{countryball_id}`) from `{original_player}` to `{user}`. Are you sure?",
+        view=view,
+        ephemeral=True,
+    )
+    await view.wait()
+    if not view.value:
+        return
+
     player, _ = await Player.objects.aget_or_create(discord_id=user.id)
     ball.player = player
     await ball.asave()

--- a/ballsdex/packages/admin/balls.py
+++ b/ballsdex/packages/admin/balls.py
@@ -267,9 +267,7 @@ async def balls_delete(ctx: commands.Context[BallsDexBot], countryball_id: str, 
 
     method = "soft" if soft_delete else "hard"
     view = ConfirmChoiceView(
-        ctx,
-        accept_message=f"Confirmed, {method} deleting...",
-        cancel_message="Request cancelled.",
+        ctx, accept_message=f"Confirmed, {method} deleting...", cancel_message="Request cancelled."
     )
     await ctx.send(
         f"You are about to {method} delete {ball.description(include_emoji=True, bot=ctx.bot)} "
@@ -317,11 +315,7 @@ async def balls_transfer(ctx: commands.Context[BallsDexBot], countryball_id: str
         await ctx.send(f"The {settings.collectible_name} ID you gave does not exist.", ephemeral=True)
         return
 
-    view = ConfirmChoiceView(
-        ctx,
-        accept_message="Confirmed, transferring...",
-        cancel_message="Request cancelled.",
-    )
+    view = ConfirmChoiceView(ctx, accept_message="Confirmed, transferring...", cancel_message="Request cancelled.")
     await ctx.send(
         f"You are about to transfer {ball.description(include_emoji=True, bot=ctx.bot)} "
         f"(ID: `{countryball_id}`) from `{original_player}` to `{user}`. Are you sure?",


### PR DESCRIPTION
## Summary
`admin balls info/delete/transfer` all take a raw hex `countryball_id` with no autocomplete or preview. This adds the safer half of the catalogue's suggestion:

- `admin balls delete` and `admin balls transfer` now resolve and **echo the ball's description and current owner** before acting, then gate the actual delete/transfer behind a `ConfirmChoiceView` - matching the existing pattern in `admin balls reset` / `admin money setdefault`.
- `admin balls info` is read-only and already echoes full detail on success, so it's unchanged.

**Not done, deliberately:** full autocomplete via a `BallInstance` transformer. The existing `BallInstanceTransformer` is built for player-ownership-scoped searches (used by `/balls give`, `/trade add`, etc.); adapting it for an unscoped, any-player admin lookup is a bigger, riskier change to shared code. The confirm+echo approach directly addresses the real risk here (an admin fat-fingering a hex ID and instantly deleting/transferring the wrong ball) without touching that shared path. Happy to follow up with real autocomplete in a separate PR if wanted.

## Test plan
- [ ] `admin balls delete` with a valid ID shows the ball + owner and requires confirmation before deleting (soft and hard)
- [ ] `admin balls transfer` with a valid ID shows the ball + both users and requires confirmation before transferring
- [ ] Cancelling either confirmation leaves the ball untouched
- [ ] Invalid/non-existent IDs still give the same early errors as before
- [ ] `ruff check .` and `pyright` pass