### PR TITLE
Polish admin history, blacklist history, and info days presets

### DIFF
--- a/ballsdex/packages/admin/blacklist.py
+++ b/ballsdex/packages/admin/blacklist.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING, cast
 
 import discord
 from discord.ext import commands
@@ -12,7 +13,10 @@ from ballsdex.core.utils.menus import Menu, ModelSource
 from bd_models.models import BlacklistedGuild, BlacklistedID, BlacklistHistory, GuildConfig, Player
 from settings.models import settings
 
-from .menu import BlacklistHistoryFormatter
+from .menu import BlacklistHistoryFormatter, BlacklistHistorySummaryFormatter
+
+if TYPE_CHECKING:
+    import discord.types.interactions
 
 log = logging.getLogger(__name__)
 
@@ -172,7 +176,8 @@ async def blacklist_history(ctx: commands.Context[BallsDexBot], user_id: str):
 
     history = BlacklistHistory.objects.filter(discord_id=_id).order_by("-date")
 
-    if not await history.aexists():
+    total = await history.acount()
+    if total == 0:
         await ctx.send("No history found for that ID.", ephemeral=True)
         return
 
@@ -182,10 +187,31 @@ async def blacklist_history(ctx: commands.Context[BallsDexBot], user_id: str):
         await ctx.send("User was not found from Discord.", ephemeral=True)
         return
 
+    async def select_callback(interaction: discord.Interaction[BallsDexBot]):
+        await interaction.response.defer(thinking=True, ephemeral=True)
+        data = cast("discord.types.interactions.SelectMessageComponentInteractionData", interaction.data)
+        entry_pk = int(data["values"][0])
+
+        detail_view = discord.ui.LayoutView()
+        detail_container = discord.ui.Container()
+        detail_view.add_item(detail_container)
+        detail_menu = Menu(
+            ctx.bot,
+            detail_view,
+            ModelSource(BlacklistHistory.objects.filter(pk=entry_pk), per_page=1),
+            BlacklistHistoryFormatter(detail_container, user),
+        )
+        await detail_menu.init()
+        await interaction.followup.send(view=detail_view, ephemeral=True)
+
     view = discord.ui.LayoutView()
-    container = discord.ui.Container()
-    view.add_item(container)
-    menu = Menu(ctx.bot, view, ModelSource(history, per_page=1), BlacklistHistoryFormatter(container, user))
+    view.add_item(discord.ui.TextDisplay(f"## Blacklist history for {user.mention} ({total} entries)"))
+    action_row = discord.ui.ActionRow()
+    select = discord.ui.Select(placeholder="Select an entry to view its full detail")
+    select.callback = select_callback
+    action_row.add_item(select)
+    view.add_item(action_row)
+    menu = Menu(ctx.bot, view, ModelSource(history, per_page=10), BlacklistHistorySummaryFormatter(select))
     await menu.init()
     await ctx.send(view=view, ephemeral=True)
 

--- a/ballsdex/packages/admin/history.py
+++ b/ballsdex/packages/admin/history.py
@@ -41,7 +41,8 @@ async def _build_history_view(
         await ctx.send("Trade cog unavailable.", ephemeral=True)
         return
 
-    if not await queryset.aexists():
+    total = await queryset.acount()
+    if total == 0:
         await ctx.send("No history found.", ephemeral=True)
         return
 
@@ -59,7 +60,7 @@ async def _build_history_view(
         await interaction.followup.send(view=view, ephemeral=True)
 
     view = LayoutView()
-    view.add_item(TextDisplay(f"## {title}"))
+    view.add_item(TextDisplay(f"## {title} ({total} trade{'s' if total != 1 else ''})"))
 
     if admin_url_path:
         view.add_item(ActionRow(Button(label="View online", url=f"{settings.site_base_url}{admin_url_path}")))

--- a/ballsdex/packages/admin/info.py
+++ b/ballsdex/packages/admin/info.py
@@ -46,6 +46,20 @@ async def info(ctx: commands.Context[BallsDexBot]):
     await ctx.send_help(ctx.command)
 
 
+_DAYS_PRESETS = (7, 14, 30, 90)
+
+
+async def _days_autocomplete(
+    interaction: discord.Interaction[BallsDexBot], current: str
+) -> list[discord.app_commands.Choice[int]]:
+    choices = [discord.app_commands.Choice(name=f"{preset} days", value=preset) for preset in _DAYS_PRESETS]
+    if current.strip().isdigit():
+        custom = int(current.strip())
+        if custom not in _DAYS_PRESETS:
+            choices.insert(0, discord.app_commands.Choice(name=f"{custom} days", value=custom))
+    return choices[:25]
+
+
 @info.command()
 @checks.has_permissions("bd_models.view_guildconfig")
 async def guild(ctx: commands.Context[BallsDexBot], guild_id: str, days: int = 7):
@@ -170,3 +184,7 @@ async def user(ctx: commands.Context[BallsDexBot], user: discord.User, days: int
     )
     embed.set_thumbnail(url=user.display_avatar)  # type: ignore
     await ctx.send(embed=embed, ephemeral=True, view=PlayerInfoView(player, user.name))
+
+
+guild.autocomplete("days")(_days_autocomplete)
+user.autocomplete("days")(_days_autocomplete)

--- a/ballsdex/packages/admin/menu.py
+++ b/ballsdex/packages/admin/menu.py
@@ -42,14 +42,19 @@ class BlacklistHistoryFormatter(menus.Formatter[QuerySet[BlacklistHistory], Cont
         )
         container.add_item(section)
         if blacklist.moderator_id:
-            moderator = await self.menu.bot.fetch_user(blacklist.moderator_id)
+            try:
+                moderator = await self.menu.bot.fetch_user(blacklist.moderator_id)
+            except discord.NotFound:
+                moderator = None
             container.add_item(Separator())
             action_type = "Blacklisted" if blacklist.action_type == "blacklist" else "Unblacklisted"
+            moderator_display = moderator.mention if moderator else f"Unknown user ({blacklist.moderator_id})"
+            avatar_url = moderator.display_avatar.url if moderator else self.user.display_avatar.url
             container.add_item(
                 Section(
-                    TextDisplay(f"### {action_type} by {moderator.mention}"),
+                    TextDisplay(f"### {action_type} by {moderator_display}"),
                     TextDisplay(f"### Reason\n{blacklist.reason}"),
-                    accessory=Thumbnail(moderator.display_avatar.url),
+                    accessory=Thumbnail(avatar_url),
                 )
             )
         if player := await Player.objects.aget_or_none(discord_id=self.user.id):

--- a/ballsdex/packages/admin/menu.py
+++ b/ballsdex/packages/admin/menu.py
@@ -1,5 +1,5 @@
 import discord
-from discord.ui import ActionRow, Button, Container, Section, Separator, TextDisplay, Thumbnail
+from discord.ui import ActionRow, Button, Container, Section, Select, Separator, TextDisplay, Thumbnail
 from discord.utils import format_dt
 from django.db.models import QuerySet
 from django.urls import reverse
@@ -7,6 +7,24 @@ from django.urls import reverse
 from ballsdex.core.utils import menus
 from bd_models.models import BlacklistHistory, Player
 from settings.models import settings
+
+
+class BlacklistHistorySummaryFormatter(menus.Formatter[QuerySet[BlacklistHistory], Select]):
+    """
+    Renders a page of BlacklistHistory entries as one-line select options, for quickly scanning a
+    long history before drilling into a single entry's full detail (see BlacklistHistoryFormatter).
+    """
+
+    async def format_page(self, page):
+        self.item.options.clear()
+        async for entry in page:
+            action = "Blacklisted" if entry.action_type == "blacklist" else "Unblacklisted"
+            reason = entry.reason or "No reason given"
+            self.item.add_option(
+                label=f"{action} - {entry.date:%Y-%m-%d %H:%M}"[:100],
+                description=reason[:100],
+                value=str(entry.pk),
+            )
 
 
 class BlacklistHistoryFormatter(menus.Formatter[QuerySet[BlacklistHistory], Container]):

--- a/ballsdex/packages/admin/menu.py
+++ b/ballsdex/packages/admin/menu.py
@@ -21,9 +21,7 @@ class BlacklistHistorySummaryFormatter(menus.Formatter[QuerySet[BlacklistHistory
             action = "Blacklisted" if entry.action_type == "blacklist" else "Unblacklisted"
             reason = entry.reason or "No reason given"
             self.item.add_option(
-                label=f"{action} - {entry.date:%Y-%m-%d %H:%M}"[:100],
-                description=reason[:100],
-                value=str(entry.pk),
+                label=f"{action} - {entry.date:%Y-%m-%d %H:%M}"[:100], description=reason[:100], value=str(entry.pk)
             )
 
 


### PR DESCRIPTION
## Summary
- `admin history user`/`admin history countryball`: header now shows the total trade count (e.g. "Trade history of X (12 trades)"), computed via a single `acount()` that replaces the old separate `aexists()` check.
- `admin blacklist history`: was 1 entry per page (slow to scan for users with a long history). Replaced with a chunked summary list (10 per page, one line per entry: action + date + truncated reason) and a "select to view" drill-in that reuses the existing rich detail formatter (moderator info, full reason, admin panel link) for just that one entry.
- `admin info user` / `admin info guild`: the `days` param now has autocomplete presets (7/14/30/90 days) while still accepting any custom integer typed in - autocomplete only suggests, it doesn't restrict.

## Deliberately not included
A balance-history view for `admin money`. There's no existing model tracking who changed a balance and when - `add`/`remove`/`set` only emit a webhook log line, nothing queryable from Discord. Building real history needs a new `MoneyHistory`-style model and a migration, which is a bigger and riskier change than the rest of this pass. Flagging it here as a good follow-up if wanted, rather than rushing a migration into this PR.

## Test plan
- [ ] `admin history user @someone` shows the trade count in the header
- [ ] `admin blacklist history <id>` for a user with several history entries shows the summary list, and selecting one shows the full detail view
- [ ] `admin info user`/`admin info guild` `days:` autocomplete suggests 7/14/30/90 and still accepts a typed custom value
- [ ] `ruff check .` and `pyright` pass