### PR TITLE
fix: allow balls count in DMs

### DIFF
--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -721,14 +721,14 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         if interaction.response.is_done():
             return
 
-        assert interaction.guild
+        guild = interaction.guild
         filters = {}
         if countryball:
             filters["ball"] = countryball
         if special:
             filters["special"] = special
-        if current_server:
-            filters["server_id"] = interaction.guild.id
+        if current_server and guild:
+            filters["server_id"] = guild.id
         filters["player__discord_id"] = interaction.user.id
 
         await interaction.response.defer(ephemeral=True, thinking=True)
@@ -740,10 +740,10 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         country = f"{countryball.country} " if countryball else ""
         plural = "s" if balls > 1 or balls == 0 else ""
         special_str = f"{special.name} " if special else ""
-        guild = f" caught in {interaction.guild.name}" if current_server else ""
+        guild_text = f" caught in {guild.name}" if current_server and guild else ""
 
         await interaction.followup.send(
-            f"You have {balls:,} {special_str}{country}{settings.collectible_name}{plural}{guild}."
+            f"You have {balls:,} {special_str}{country}{settings.collectible_name}{plural}{guild_text}."
         )
 
     @app_commands.command()

--- a/ballsdex/packages/balls/cog.py
+++ b/ballsdex/packages/balls/cog.py
@@ -701,7 +701,6 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         interaction: discord.Interaction["BallsDexBot"],
         countryball: BallEnabledTransform | None = None,
         special: SpecialEnabledTransform | None = None,
-        current_server: bool = False,
         filter: FilteringChoices | None = None,
     ):
         """
@@ -713,8 +712,6 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
             The countryball you want to count
         special: Special
             The special you want to count
-        current_server: bool
-            Only count countryballs caught in the current server
         filter: FilteringChoices
             Filter the count by a specific filter
         """
@@ -727,8 +724,6 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
             filters["ball"] = countryball
         if special:
             filters["special"] = special
-        if current_server and guild:
-            filters["server_id"] = guild.id
         filters["player__discord_id"] = interaction.user.id
 
         await interaction.response.defer(ephemeral=True, thinking=True)
@@ -740,7 +735,7 @@ class Balls(commands.GroupCog, group_name=settings.balls_slash_name):
         country = f"{countryball.country} " if countryball else ""
         plural = "s" if balls > 1 or balls == 0 else ""
         special_str = f"{special.name} " if special else ""
-        guild_text = f" caught in {guild.name}" if current_server and guild else ""
+        guild_text = f" caught in {guild.name}" if filter == FilteringChoices.this_server and guild else ""
 
         await interaction.followup.send(
             f"You have {balls:,} {special_str}{country}{settings.collectible_name}{plural}{guild_text}."


### PR DESCRIPTION
Closes #807.

## Summary
- remove the unconditional guild assertion from `/balls count`
- only apply current-server filtering and guild display text when the interaction has a guild
- allow the command to return the regular global count from DMs

## Verification
- `uv sync --extra dev`
- `uv run ruff check ballsdex/packages/balls/cog.py`
- `uv run python -m py_compile ballsdex/packages/balls/cog.py`