### PR TITLE
Change media path to /admin_panel/media.

### DIFF
--- a/admin_panel/admin_panel/settings/base.py
+++ b/admin_panel/admin_panel/settings/base.py
@@ -198,7 +198,7 @@ STATIC_ROOT = os.environ.get("STATIC_ROOT", "static")
 STATICFILES_DIRS = ["staticfiles"]
 
 MEDIA_URL = "media/"
-MEDIA_ROOT = "media"
+MEDIA_ROOT = BASE_DIR.parent / "media"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field


### PR DESCRIPTION
### Description of the changes
This pull request resolves the issue of the media folder being the media folder in the bot's main folder, e.g. `/BallsDex-DiscordBot/media`.
### Were the changes in this PR tested?
- [x] Yes
