### PR TITLE
Add monorepo auto-discovery support

### DIFF
--- a/bdextra.py
+++ b/bdextra.py
@@ -13,6 +13,9 @@ if sys.version_info.major < 3 or sys.version_info.minor < 11:
     sys.exit(1)
 
 import tomllib
+import tempfile
+import subprocess
+from pathlib import Path
 from typing import NotRequired, TypedDict
 
 
@@ -23,10 +26,67 @@ class Package(TypedDict, total=True):
     editable: NotRequired[bool]
 
 
+def discover_monorepo_packages(location: str) -> list[Package]:
+    packages = []
+    
+    if location.startswith("git+"):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                git_url = location.replace("git+", "", 1)
+                
+                if "==" in git_url:
+                    git_url, version = git_url.rsplit("==", 1)
+                    version = f"=={version}"
+                else:
+                    version = ""
+                
+                subprocess.run(
+                    ["git", "clone", "--depth", "1", git_url, tmpdir],
+                    capture_output=True,
+                    check=True,
+                    timeout=30,
+                )
+                
+                repo_path = Path(tmpdir)
+                git_location = f"git+{git_url}{version}"
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+                warn(f"Failed to clone git repository: {location}")
+                return packages
+            else:
+                repo_path = Path(location)
+                git_location = location
+    else:
+        repo_path = Path(location)
+        git_location = location
+    
+    if not repo_path.exists():
+        warn(f"Path does not exist: {location}")
+        return packages
+    
+    root_pyproject = repo_path / "pyproject.toml"
+    
+    for pyproject in repo_path.rglob("pyproject.toml"):
+        if pyproject == root_pyproject:
+            continue
+        
+        package_path = pyproject.parent.relative_to(repo_path)
+        
+        packages.append({
+            "location": git_location,
+            "path": str(package_path),
+            "enabled": True,
+            "editable": True,
+        })
+    
+    return packages
+
+
 def list_pip_packages(packages: list[Package]):
     print(
         " ".join(
-            f"{'-e ' if x.get('editable', False) else ''}{x['location']}"
+            f"{'-e ' if x.get('editable', False) else ''}{x['location']}/{x['path']}"
+            if x["path"]
+            else f"{'-e ' if x.get('editable', False) else ''}{x['location']}"
             for x in packages
             if x["enabled"] and x["location"]
         )
@@ -40,8 +100,18 @@ def main(toml_file: str):
     except FileNotFoundError:
         warn("No extra.toml file found.")
         return
+    
     packages: list[Package] = contents.get("ballsdex", {}).get("packages", [])
-    list_pip_packages(packages)
+    
+    expanded_packages = []
+    for pkg in packages:
+        if pkg.get("path") == "*":
+            discovered = discover_monorepo_packages(pkg["location"])
+            expanded_packages.extend(discovered)
+        else:
+            expanded_packages.append(pkg)
+    
+    list_pip_packages(expanded_packages)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of the changes

- Adds support for wildcard path (`*`) to auto-discover all packages in a git monorepo
- Intelligently skips root-level pyproject.toml files (typically for tooling/typesafety)
- Maintains backward compatibility with existing single-package configurations
- Works with both git URLs and local filesystem paths
- No breaking changes to existing extra.toml configurations

Example usage:
```toml
[[ballsdex.packages]]
location = "git+https://github.com/user/monorepo.git"
path = "*"
enabled = true
```

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->

### Were the changes in this PR tested?

<!--
Answer yes or no if you tested your changes locally.
To answer, add an "x" in between the square brackets [x] for the option you want to choose. 

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
- [ ] Yes
- [x] No

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->
